### PR TITLE
Add onError hook to promise domains

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,10 +18,13 @@ Imports:
     magrittr
 Suggests:
     testthat,
-    future
+    future,
+    knitr,
+    rmarkdown
 LinkingTo: later,
     Rcpp
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1
 Encoding: UTF-8
 LazyData: true
+VignetteBuilder: knitr

--- a/R/domains.R
+++ b/R/domains.R
@@ -113,6 +113,11 @@ reenter_promise_domain <- function(domain, expr, replace = FALSE) {
 #'   expression that the function should [force()]. This expression represents
 #'   the `expr` argument passed to [with_promise_domain()]; `wrapSync` allows
 #'   the domain to manipulate the environment before/after `expr` is evaluated.
+#' @param onError A function that takes a single argument: an error. `onError`
+#'   will be called whenever an exception occurs in a domain (that isn't caught
+#'   by a `tryCatch`). Providing an `onError` callback doesn't cause errors to
+#'   be caught, necessarily; instead, `onError` callbacks behave like calling
+#'   handlers.
 #' @param ... Arbitrary named values that will become elements of the promise
 #'   domain object, and can be accessed as items in an environment (i.e. using
 #'   `[[` or `$`).
@@ -142,14 +147,14 @@ compose_domains <- function(base, new) {
 
   list(
     wrapOnFulfilled = function(onFulfilled) {
-      new$wrapOnFulfilled(
-        base$wrapOnFulfilled(onFulfilled)
-      )
+      # Force eager evaluation of base$wrapOnFulfilled(onFulfilled)
+      base <- base$wrapOnFulfilled(onFulfilled)
+      new$wrapOnFulfilled(base)
     },
     wrapOnRejected = function(onRejected) {
-      new$wrapOnRejected(
-        base$wrapOnRejected(onRejected)
-      )
+      # Force eager evaluation of base$wrapOnRejected(onRejected)
+      base <- base$wrapOnRejected(onRejected)
+      new$wrapOnRejected(base)
     },
     # Only include the new wrapSync, assuming that we've already applied the
     # base domain's wrapSync. This assumption won't hold if we either export

--- a/R/promise.R
+++ b/R/promise.R
@@ -54,22 +54,22 @@ Promise <- R6::R6Class("Promise",
       private$state <- "fulfilled"
 
       later::later(function() {
-        lapply(private$onFulfilled, function(f) {
-          f(private$value, private$visible)
+          lapply(private$onFulfilled, function(f) {
+            f(private$value, private$visible)
+          })
+          private$onFulfilled <- list()
         })
-        private$onFulfilled <- list()
-      })
     },
     doRejectFinalReason = function(reason) {
       private$value <- reason
       private$state <- "rejected"
 
       later::later(function() {
-        lapply(private$onRejected, function(f) {
-          private$rejectionHandled <- TRUE
-          f(private$value)
-        })
-        private$onRejected <- list()
+          lapply(private$onRejected, function(f) {
+            private$rejectionHandled <- TRUE
+            f(private$value)
+          })
+          private$onRejected <- list()
 
         later::later(~{
           if (!private$rejectionHandled) {
@@ -133,50 +133,50 @@ Promise <- R6::R6Class("Promise",
 
       promise2 <- promise(function(resolve, reject) {
 
-        res <- promiseDomain$onThen(onFulfilled, onRejected)
-        if (!is.null(res)) {
-          onFulfilled <- res$onFulfilled
-          onRejected <- res$onRejected
-        }
-
-        handleFulfill <- function(value, visible) {
-          if (is.function(onFulfilled)) {
-            resolve(onFulfilled(value, visible))
-          } else {
-            resolve(if (visible) value else invisible(value))
+          res <- promiseDomain$onThen(onFulfilled, onRejected)
+          if (!is.null(res)) {
+            onFulfilled <- res$onFulfilled
+            onRejected <- res$onRejected
           }
-        }
 
-        handleReject <- function(reason) {
-          if (is.function(onRejected)) {
-            # Yes, resolve, not reject.
-            resolve(onRejected(reason))
-          } else {
-            # Yes, reject, not resolve.
-            reject(reason)
+          handleFulfill <- function(value, visible) {
+            if (is.function(onFulfilled)) {
+              resolve(onFulfilled(value, visible))
+            } else {
+              resolve(if (visible) value else invisible(value))
+            }
           }
-        }
 
-        if (private$state == "pending") {
-          private$onFulfilled <- c(private$onFulfilled, list(
-            handleFulfill
-          ))
-          private$onRejected <- c(private$onRejected, list(
-            handleReject
-          ))
-        } else if (private$state == "fulfilled") {
-          later::later(function() {
-            handleFulfill(private$value, private$visible)
-          })
-        } else if (private$state == "rejected") {
-          later::later(function() {
-            private$rejectionHandled <- TRUE
-            handleReject(private$value)
-          })
-        } else {
-          stop("Unexpected state ", private$state)
-        }
-      })
+          handleReject <- function(reason) {
+            if (is.function(onRejected)) {
+              # Yes, resolve, not reject.
+              resolve(onRejected(reason))
+            } else {
+              # Yes, reject, not resolve.
+              reject(reason)
+            }
+          }
+
+          if (private$state == "pending") {
+            private$onFulfilled <- c(private$onFulfilled, list(
+              handleFulfill
+            ))
+            private$onRejected <- c(private$onRejected, list(
+              handleReject
+            ))
+          } else if (private$state == "fulfilled") {
+            later::later(function() {
+              handleFulfill(private$value, private$visible)
+            })
+          } else if (private$state == "rejected") {
+            later::later(function() {
+              private$rejectionHandled <- TRUE
+              handleReject(private$value)
+            })
+          } else {
+            stop("Unexpected state ", private$state)
+          }
+        })
 
       invisible(promise2)
     },
@@ -406,7 +406,7 @@ as.promise.Future <- function(x) {
 #' @export
 as.promise.default <- function(x) {
   # TODO: If x is an error or try-error, should this return a rejected promise?
-  promise(~resolve(x))
+  stop("Don't know how to convert object of class ", class(x)[[1L]], " into a promise")
 }
 
 #' Fulfill a promise

--- a/R/utils.R
+++ b/R/utils.R
@@ -103,6 +103,8 @@ promise_lapply <- function(X, FUN, ...) {
     if (pos > length(results)) {
       return(stats::setNames(results, X_names))
     } else {
+      # The next line may throw, that's fine, it will be caught by resolve() and
+      # reject the promise
       this_result <- FUN(X[[pos]], ...)
       as.promise(this_result) %...>%
         (function(this_value) {

--- a/man/with_promise_domain.Rd
+++ b/man/with_promise_domain.Rd
@@ -8,7 +8,7 @@
 with_promise_domain(domain, expr, replace = FALSE)
 
 new_promise_domain(wrapOnFulfilled = identity, wrapOnRejected = identity,
-  wrapSync = force, ...)
+  wrapSync = force, onError = force, ...)
 }
 \arguments{
 \item{domain}{A promise domain object to install while \code{expr} is evaluated.}
@@ -35,6 +35,12 @@ that was passed as an \code{onRejected} argument to \code{\link[=then]{then()}}.
 expression that the function should \code{\link[=force]{force()}}. This expression represents
 the \code{expr} argument passed to \code{\link[=with_promise_domain]{with_promise_domain()}}; \code{wrapSync} allows
 the domain to manipulate the environment before/after \code{expr} is evaluated.}
+
+\item{onError}{A function that takes a single argument: an error. \code{onError}
+will be called whenever an exception occurs in a domain (that isn't caught
+by a \code{tryCatch}). Providing an \code{onError} callback doesn't cause errors to
+be caught, necessarily; instead, \code{onError} callbacks behave like calling
+handlers.}
 
 \item{...}{Arbitrary named values that will become elements of the promise
 domain object, and can be accessed as items in an environment (i.e. using


### PR DESCRIPTION
This allows Shiny to add stack traces (including deep stack traces). Eventually this functionality should be in a separate package from both promises and Shiny.