### PR TITLE
Fix #18: `finally` causes `invisible()` to be dropped

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: promises
 Type: Package
 Title: Abstractions for Promise-Based Asynchronous Programming
-Version: 1.0.1
+Version: 1.0.9000
 Authors@R: c(
       person("Joe", "Cheng", email = "joe@rstudio.com", role = c("aut", "cre")),
       person("RStudio", role = c("cph", "fnd"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+promises 1.1
+================
+
+- Fix bug: `finally` causes `invisible()` to be dropped (issue [#18](https://github.com/rstudio/promises/issues/18), PR [#19](https://github.com/rstudio/promises/pull/19))
+
 promises 1.0
 ================
 

--- a/R/promise.R
+++ b/R/promise.R
@@ -187,9 +187,12 @@ Promise <- R6::R6Class("Promise",
     },
     finally = function(onFinally) {
       invisible(self$then(
-        onFulfilled = function(value) {
+        onFulfilled = function(value, .visible) {
           onFinally()
-          value
+          if (.visible)
+            value
+          else
+            invisible(value)
         },
         onRejected = function(reason) {
           onFinally()

--- a/tests/testthat/test-visibility.R
+++ b/tests/testthat/test-visibility.R
@@ -1,0 +1,25 @@
+library(testthat)
+
+source("common.R")
+
+describe("visibility", {
+  it("survives catch, finally", {
+    p <- promise_resolve(invisible(1)) %>%
+      catch(~{}) %>%
+      finally(~{}) %>%
+      then(function(x, .visible) {
+        .visible
+      })
+
+    expect_false(extract(p))
+
+    p <- promise_resolve(1) %>%
+      catch(~{}) %>%
+      finally(~{}) %>%
+      then(function(x, .visible) {
+        .visible
+      })
+
+    expect_true(extract(p))
+  })
+})


### PR DESCRIPTION
**Testing notes:** See https://github.com/rstudio/promises/issues/18 for repro