### PR TITLE
Handle FutureError:s during future::resolved()

### DIFF
--- a/R/promise.R
+++ b/R/promise.R
@@ -427,13 +427,21 @@ as.promise.Future <- function(x) {
     poll_interval <- 0.1
     check <- function() {
       # timeout = 0 is important, the default waits for 200ms
-      if (future::resolved(x, timeout = 0)) {
+      is_resolved <- tryCatch({
+        future::resolved(x, timeout = 0)
+      }, FutureError = function(e) {
+         reject(e)
+         TRUE
+      })
+      if (is_resolved) {
         tryCatch(
           {
             result <- future::value(x, signal = TRUE)
             resolve(result)
-          },
-          error = function(e) {
+          }, FutureError = function(e) {
+            reject(e)
+            TRUE
+          }, error = function(e) {
             reject(e)
           }
         )


### PR DESCRIPTION
Handle FutureError:s during `future::resolved()` by discarding the corrupt future. Same for `future::value()`.

This addresses https://github.com/HenrikBengtsson/future/issues/261