### PR TITLE
Add `wrapOnFinally` to promise domains

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: promises
 Type: Package
 Title: Abstractions for Promise-Based Asynchronous Programming
-Version: 1.0.1.9001
+Version: 1.0.1.9002
 Authors@R: c(
       person("Joe", "Cheng", email = "joe@rstudio.com", role = c("aut", "cre")),
       person("RStudio", role = c("cph", "fnd"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,13 +3,7 @@ promises 1.0.1.9002
 
 * Fixed [#49](https://github.com/rstudio/promises/issues/49): `promise_all()` previously did not handle `NULL` values correctly. ([#50](https://github.com/rstudio/promises/pull/50))
 
-- `new_promise_domain` now takes a `wrapOnFinally` argument, which can be used
-  to intercept registration of `finally()`. Previous versions treated `finally`
-  as passing the same callback to `then(onFulfilled=..., onRejected=...)`, and
-  ignoring the result; for backward compatibility, promise domains will still
-  treat `finally` that way by default (i.e. if `wrapOnFinally` is `NULL`, then
-  `finally` will result in `wrapOnFulfilled` and `wrapOnRejected` being called,
-  but if `wrapOnFinally` is provided then only `wrapOnFinally` will be called).
+* `new_promise_domain` now takes a `wrapOnFinally` argument, which can be used to intercept registration of `finally()`. Previous versions treated `finally` as passing the same callback to `then(onFulfilled=..., onRejected=...)`, and ignoring the result; for backward compatibility, promise domains will still treat `finally` that way by default (i.e. if `wrapOnFinally` is `NULL`, then `finally` will result in `wrapOnFulfilled` and `wrapOnRejected` being called, but if `wrapOnFinally` is provided then only `wrapOnFinally` will be called). ([#43](https://github.com/rstudio/promises/pull/43))
 
 
 promises 1.0.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,18 @@
-promises 1.0.1.9001
-================
+promises 1.0.1.9002
+===================
 
 * Fixed [#49](https://github.com/rstudio/promises/issues/49): `promise_all()` previously did not handle `NULL` values correctly. ([#50](https://github.com/rstudio/promises/pull/50))
 
+- `new_promise_domain` now takes a `wrapOnFinally` argument, which can be used
+  to intercept registration of `finally()`. Previous versions treated `finally`
+  as passing the same callback to `then(onFulfilled=..., onRejected=...)`, and
+  ignoring the result; for backward compatibility, promise domains will still
+  treat `finally` that way by default (i.e. if `wrapOnFinally` is `NULL`, then
+  `finally` will result in `wrapOnFulfilled` and `wrapOnRejected` being called,
+  but if `wrapOnFinally` is provided then only `wrapOnFinally` will be called).
+
+
 promises 1.0.1
-================
+==============
 
 * Initial CRAN release

--- a/R/domains.R
+++ b/R/domains.R
@@ -166,6 +166,14 @@ reenter_promise_domain <- function(domain, expr, replace = FALSE) {
 #' @param ... Arbitrary named values that will become elements of the promise
 #'   domain object, and can be accessed as items in an environment (i.e. using
 #'   `[[` or `$`).
+#' @param wrapOnFinally A function that takes a single argument: a function
+#'   that was passed as an `onFinally` argument to [then()]. The
+#'   `wrapOnFinally` function should return a function that is suitable for
+#'   `onFinally` duty. If `wrapOnFinally` is `NULL` (the default), then the
+#'   domain will use both `wrapOnFulfilled` and `wrapOnRejected` to wrap the
+#'   `onFinally`. If it's important to distinguish between normal
+#'   fulfillment/rejection handlers and finally handlers, then be sure to
+#'   provide `wrapOnFinally`, even if it's just [base::identity()].
 #' @rdname with_promise_domain
 #' @export
 new_promise_domain <- function(

--- a/R/domains.R
+++ b/R/domains.R
@@ -49,6 +49,9 @@ promiseDomain <- list(
     }
 
     # TODO: All wrapped functions should also be rewritten to reenter the domain
+    # jcheng 2019-07-26: Actually, this seems not to be necessary--the domain
+    # is getting reentered during callbacks. But I can't figure out now how it's
+    # happening.
 
     domain <- current_promise_domain()
 

--- a/R/domains.R
+++ b/R/domains.R
@@ -54,12 +54,14 @@ promiseDomain <- list(
 
     shouldWrapFinally <- !is.null(onFinally) && !is.null(domain) && !is.null(domain$wrapOnFinally)
 
-    if (shouldWrapFinally) {
-      onFinally <- domain$wrapOnFinally(onFinally)
+    newOnFinally <- if (shouldWrapFinally) {
+      domain$wrapOnFinally(onFinally)
+    } else {
+      onFinally
     }
 
-    if (!is.null(onFinally)) {
-      spliced <- spliceOnFinally(onFinally)
+    if (!is.null(newOnFinally)) {
+      spliced <- spliceOnFinally(newOnFinally)
       onFulfilled <- spliced$onFulfilled
       onRejected <- spliced$onRejected
     }

--- a/R/promise.R
+++ b/R/promise.R
@@ -142,7 +142,9 @@ Promise <- R6::R6Class("Promise",
     then = function(onFulfilled = NULL, onRejected = NULL, onFinally = NULL) {
       onFulfilled <- normalizeOnFulfilled(onFulfilled)
       onRejected <- normalizeOnRejected(onRejected)
-      # TODO: Verify onFinally is NULL or has one argument
+      if (!is.function(onFinally)) {
+        onFinally <- NULL
+      }
 
       promise2 <- promise(function(resolve, reject) {
           res <- promiseDomain$onThen(onFulfilled, onRejected, onFinally)
@@ -216,7 +218,7 @@ Promise <- R6::R6Class("Promise",
 
 normalizeOnFulfilled <- function(onFulfilled) {
   if (!is.function(onFulfilled))
-    return(onFulfilled)
+    return(NULL)
 
   args <- formals(onFulfilled)
   arg_count <- length(args)
@@ -236,7 +238,7 @@ normalizeOnFulfilled <- function(onFulfilled) {
 
 normalizeOnRejected <- function(onRejected) {
   if (!is.function(onRejected))
-    return(onRejected)
+    return(NULL)
 
   args <- formals(onRejected)
   arg_count <- length(args)

--- a/R/promise.R
+++ b/R/promise.R
@@ -29,10 +29,15 @@ Promise <- R6::R6Class("Promise",
         if (identical(self, attr(value, "promise_impl", exact = TRUE))) {
           return(private$doReject(simpleError("Chaining cycle detected for promise")))
         }
-        value$then(
-          private$doResolve,
-          private$doReject
-        )
+        # This then() call doesn't need promise domains; semantically, it doesn't
+        # really exist, as it's just a convenient way to implement the new promise
+        # inhabiting the old promise's corpse.
+        without_promise_domain({
+          value$then(
+            private$doResolve,
+            private$doReject
+          )
+        })
       } else {
         private$doResolveFinalValue(value, visible)
       }
@@ -40,10 +45,15 @@ Promise <- R6::R6Class("Promise",
     doReject = function(reason) {
       if (is.promising(reason)) {
         reason <- as.promise(reason)
-        reason$then(
-          private$doResolve,
-          private$doReject
-        )
+        # This then() call doesn't need promise domains; semantically, it doesn't
+        # really exist, as it's just a convenient way to implement the new promise
+        # inhabiting the old promise's corpse.
+        without_promise_domain({
+          reason$then(
+            private$doResolve,
+            private$doReject
+          )
+        })
       } else {
         private$doRejectFinalReason(reason)
       }
@@ -129,13 +139,14 @@ Promise <- R6::R6Class("Promise",
 
       invisible()
     },
-    then = function(onFulfilled = NULL, onRejected = NULL) {
+    then = function(onFulfilled = NULL, onRejected = NULL, onFinally = NULL) {
       onFulfilled <- normalizeOnFulfilled(onFulfilled)
       onRejected <- normalizeOnRejected(onRejected)
+      # TODO: Verify onFinally is NULL or has one argument
 
       promise2 <- promise(function(resolve, reject) {
+          res <- promiseDomain$onThen(onFulfilled, onRejected, onFinally)
 
-          res <- promiseDomain$onThen(onFulfilled, onRejected)
           if (!is.null(res)) {
             onFulfilled <- res$onFulfilled
             onRejected <- res$onRejected
@@ -187,14 +198,7 @@ Promise <- R6::R6Class("Promise",
     },
     finally = function(onFinally) {
       invisible(self$then(
-        onFulfilled = function(value) {
-          onFinally()
-          value
-        },
-        onRejected = function(reason) {
-          onFinally()
-          stop(reason)
-        }
+        onFinally = onFinally
       ))
     },
     format = function() {

--- a/man/with_promise_domain.Rd
+++ b/man/with_promise_domain.Rd
@@ -8,7 +8,8 @@
 with_promise_domain(domain, expr, replace = FALSE)
 
 new_promise_domain(wrapOnFulfilled = identity,
-  wrapOnRejected = identity, wrapSync = force, onError = force, ...)
+  wrapOnRejected = identity, wrapSync = force, onError = force, ...,
+  wrapOnFinally = NULL)
 }
 \arguments{
 \item{domain}{A promise domain object to install while \code{expr} is evaluated.}
@@ -45,6 +46,15 @@ handlers.}
 \item{...}{Arbitrary named values that will become elements of the promise
 domain object, and can be accessed as items in an environment (i.e. using
 \code{[[} or \code{$}).}
+
+\item{wrapOnFinally}{A function that takes a single argument: a function
+that was passed as an \code{onFinally} argument to \code{\link[=then]{then()}}. The
+\code{wrapOnFinally} function should return a function that is suitable for
+\code{onFinally} duty. If \code{wrapOnFinally} is \code{NULL} (the default), then the
+domain will use both \code{wrapOnFulfilled} and \code{wrapOnRejected} to wrap the
+\code{onFinally}. If it's important to distinguish between normal
+fulfillment/rejection handlers and finally handlers, then be sure to
+provide \code{wrapOnFinally}, even if it's just \code{\link[base:identity]{base::identity()}}.}
 }
 \description{
 Promise domains are used to temporarily set up custom environments that

--- a/tests/testthat/test-domains.R
+++ b/tests/testthat/test-domains.R
@@ -42,4 +42,79 @@ describe("Promise domains", {
 
     expect_identical(cd$counts$onFulfilledBound, 2L)
   })
+
+  it("pass finally binding to fulfill/reject by default", {
+    cd1 <- create_counting_domain(trackFinally = FALSE)
+
+    with_promise_domain(cd1, {
+      p1 <- promise_resolve(TRUE) %>%
+        finally(~{
+          expect_identical(cd1$counts$onFulfilledActive, 1L)
+          expect_identical(cd1$counts$onRejectedActive, 0L)
+        })
+      expect_identical(cd1$counts$onFulfilledBound, 1L)
+      expect_identical(cd1$counts$onRejectedBound, 1L)
+      wait_for_it()
+      expect_identical(cd1$counts$onFulfilledCalled, 1L)
+      expect_identical(cd1$counts$onRejectedCalled, 0L)
+    })
+
+    cd2 <- create_counting_domain(trackFinally = FALSE)
+
+    with_promise_domain(cd2, {
+      p1 <- promise_reject("a problem") %>%
+        finally(~{
+          expect_identical(cd2$counts$onFulfilledActive, 0L)
+          expect_identical(cd2$counts$onRejectedActive, 1L)
+        })
+      expect_identical(cd2$counts$onFulfilledBound, 1L)
+      expect_identical(cd2$counts$onRejectedBound, 1L)
+      p1
+    }) %>% squelch_unhandled_promise_error()
+
+    wait_for_it()
+    expect_identical(cd2$counts$onFulfilledCalled, 0L)
+    expect_identical(cd2$counts$onRejectedCalled, 1L)
+  })
+
+  it("doesn't intercept fulfill/reject on finally, if finally is explicitly intercepted", {
+    cd1 <- create_counting_domain(trackFinally = TRUE)
+
+    with_promise_domain(cd1, {
+      p1 <- promise_resolve(TRUE) %>%
+        finally(~{
+          expect_identical(cd1$counts$onFinallyActive, 1L)
+          expect_identical(cd1$counts$onFulfilledActive, 0L)
+          expect_identical(cd1$counts$onRejectedActive, 0L)
+        })
+      expect_identical(cd1$counts$onFinallyBound, 1L)
+      expect_identical(cd1$counts$onFulfilledBound, 0L)
+      expect_identical(cd1$counts$onRejectedBound, 0L)
+      wait_for_it()
+      expect_identical(cd1$counts$onFinallyCalled, 1L)
+      expect_identical(cd1$counts$onFulfilledCalled, 0L)
+      expect_identical(cd1$counts$onRejectedCalled, 0L)
+    })
+
+    cd2 <- create_counting_domain(trackFinally = TRUE)
+
+    with_promise_domain(cd2, {
+      p2 <- promise_reject(TRUE) %>%
+        finally(~{
+          expect_identical(cd2$counts$onFinallyActive, 1L)
+          expect_identical(cd2$counts$onFulfilledActive, 0L)
+          expect_identical(cd2$counts$onRejectedActive, 0L)
+        })
+      expect_identical(cd2$counts$onFinallyBound, 1L)
+      expect_identical(cd2$counts$onFulfilledBound, 0L)
+      expect_identical(cd2$counts$onRejectedBound, 0L)
+      p2
+    }) %>% squelch_unhandled_promise_error()
+
+    wait_for_it()
+    expect_identical(cd2$counts$onFinallyCalled, 1L)
+    expect_identical(cd2$counts$onFulfilledCalled, 0L)
+    expect_identical(cd2$counts$onRejectedCalled, 0L)
+  })
+
 })

--- a/tests/testthat/test-domains.R
+++ b/tests/testthat/test-domains.R
@@ -41,6 +41,21 @@ describe("Promise domains", {
     })
 
     expect_identical(cd$counts$onFulfilledBound, 2L)
+
+    with_promise_domain(cd, {
+      p <- p %...>% {
+        expect_identical(cd$counts$onFulfilledCalled, 3L)
+        # This tests if promise domain membership infects subscriptions made
+        # in handlers.
+        p %...>% {
+          expect_true(!is.null(current_promise_domain()))
+          expect_identical(cd$counts$onFulfilledCalled, 4L)
+        }
+      }
+    })
+    expect_true(is.null(current_promise_domain()))
+    expect_identical(cd$counts$onFulfilledCalled, 2L)
+    wait_for_it()
   })
 
   it("pass finally binding to fulfill/reject by default", {

--- a/tests/testthat/test-domains.R
+++ b/tests/testthat/test-domains.R
@@ -1,0 +1,45 @@
+context("Promise domains")
+
+source("common.R")
+
+describe("Promise domains", {
+
+  it("are reentered during handlers", {
+    cd <- create_counting_domain(trackFinally = TRUE)
+    p <- with_promise_domain(cd, {
+      promise_resolve(TRUE) %...>% {
+        expect_identical(cd$counts$onFulfilledCalled, 1L)
+        expect_identical(cd$counts$onFulfilledActive, 1L)
+        10 # sync result
+      } %...>% {
+        expect_identical(cd$counts$onFulfilledCalled, 2L)
+        expect_identical(cd$counts$onFulfilledActive, 1L)
+        promise_resolve(20) # async result
+      }
+    })
+
+    expect_identical(cd$counts$onFulfilledBound, 2L)
+
+    p <- p %...>% {
+      expect_identical(cd$counts$onFulfilledCalled, 2L)
+      expect_identical(cd$counts$onFulfilledActive, 0L)
+    }
+
+    expect_identical(cd$counts$onFulfilledBound, 2L)
+
+    with_promise_domain(cd, {
+      p <- p %>% finally(~{
+        expect_identical(cd$counts$onFinallyCalled, 1L)
+        expect_identical(cd$counts$onFinallyActive, 1L)
+      })
+      expect_identical(cd$counts$onFinallyBound, 1L)
+
+      expect_identical(cd$counts$onFulfilledBound, 2L)
+      expect_identical(cd$counts$onRejectedBound, 0L)
+
+      wait_for_it()
+    })
+
+    expect_identical(cd$counts$onFulfilledBound, 2L)
+  })
+})

--- a/tests/testthat/test-domains.R
+++ b/tests/testthat/test-domains.R
@@ -67,11 +67,11 @@ describe("Promise domains", {
           expect_identical(cd2$counts$onFulfilledActive, 0L)
           expect_identical(cd2$counts$onRejectedActive, 1L)
         })
-      expect_identical(cd2$counts$onFulfilledBound, 1L)
-      expect_identical(cd2$counts$onRejectedBound, 1L)
       p1
     }) %>% squelch_unhandled_promise_error()
 
+    expect_identical(cd2$counts$onFulfilledBound, 1L)
+    expect_identical(cd2$counts$onRejectedBound, 1L)
     wait_for_it()
     expect_identical(cd2$counts$onFulfilledCalled, 0L)
     expect_identical(cd2$counts$onRejectedCalled, 1L)
@@ -105,12 +105,12 @@ describe("Promise domains", {
           expect_identical(cd2$counts$onFulfilledActive, 0L)
           expect_identical(cd2$counts$onRejectedActive, 0L)
         })
-      expect_identical(cd2$counts$onFinallyBound, 1L)
-      expect_identical(cd2$counts$onFulfilledBound, 0L)
-      expect_identical(cd2$counts$onRejectedBound, 0L)
       p2
     }) %>% squelch_unhandled_promise_error()
 
+    expect_identical(cd2$counts$onFinallyBound, 1L)
+    expect_identical(cd2$counts$onFulfilledBound, 0L)
+    expect_identical(cd2$counts$onRejectedBound, 0L)
     wait_for_it()
     expect_identical(cd2$counts$onFinallyCalled, 1L)
     expect_identical(cd2$counts$onFulfilledCalled, 0L)

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -30,6 +30,14 @@ describe("then()", {
     expect_identical(result$value, 1)
     expect_identical(result$visible, FALSE)
   })
+  it("method ignores non-functions or NULL...", {
+    p1 <- promise(~resolve(1))$then(10)$then(NULL)
+    expect_identical(extract(p1), 1)
+  })
+  it("...but function only ignores NULL, not non-functions", {
+    expect_error(promise(~resolve(1)) %>% then(10))
+    expect_error(promise(~resolve(1)) %>% then(NULL), NA)
+  })
 })
 
 describe("catch()", {
@@ -42,6 +50,14 @@ describe("catch()", {
   it("can throw", {
     p <- promise(~stop("foo")) %>% catch(~stop("bar"))
     expect_error(extract(p), "^bar$")
+  })
+  it("method ignores non-functions or NULL...", {
+    p1 <- promise(~resolve(1))$catch(10)$catch(NULL)
+    expect_identical(extract(p1), 1)
+  })
+  it("...but function only ignores NULL, not non-functions", {
+    expect_error(promise(~resolve(1)) %>% catch(10))
+    expect_error(promise(~resolve(1)) %>% catch(NULL), NA)
   })
 })
 
@@ -80,6 +96,14 @@ describe("finally()", {
 
     p2 <- promise(~reject("foo")) %>% finally(~stop("bar"))
     expect_error(extract(p2), "^bar$")
+  })
+  it("method ignores non-functions or NULL...", {
+    p1 <- promise(~resolve(1))$finally(10)$finally(NULL)
+    expect_identical(extract(p1), 1)
+  })
+  it("...but function only ignores NULL, not non-functions", {
+    expect_error(promise(~resolve(1)) %>% finally(10))
+    expect_error(promise(~resolve(1)) %>% finally(NULL), NA)
   })
 })
 


### PR DESCRIPTION
This feature adds the ability for promise domains to handle `finally` differently than `resolved`/`rejected`.

When using private event loops to implement synchronous functions on top of promises, we need to take special care to make sure `finally` handlers get called even in the face of R interrupt. We can implement this with a promise domain, but only if promise domains can distinguish between `finally` and regular `resolve`/`reject` semantics. This causes the notion of `finally` to be pushed a little deeper into the promise abstractions, as previously it was literally just syntactic sugar over the regular `then`. Now, `then` has an explicit `onFinally`; though once promise domains encounter the finally handler, we then immediately split the finally into resolve/reject so it doesn't complicate the actual implementation of `doResolve`/`doReject` and friends.