### PR TITLE
Support `Promise$then(onFulfilled)` visibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: promises
 Type: Package
 Title: Abstractions for Promise-Based Asynchronous Programming
-Version: 1.1.1.9000
+Version: 1.1.1.9001
 Authors@R: c(
       person("Joe", "Cheng", email = "joe@rstudio.com", role = c("aut", "cre")),
       person("RStudio", role = c("cph", "fnd"))
@@ -27,7 +27,7 @@ Suggests:
 LinkingTo: later,
     Rcpp
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,15 @@
-promises 1.1.1.9000
+promises (development)
 ==============
+
+- Fix bug: `then(function(value) {})` causes `invisible()` to be dropped (#59)
+- Fix bug: `finally` causes `invisible()` to be dropped (#59)
 
 
 promises 1.1.1
 ==============
 
 * Fix handling of FutureErrors during `future::resolved()` and `future::value()` by discarding the corrupt future. (#37)
+
 
 promises 1.1.0
 ==============

--- a/R/promise.R
+++ b/R/promise.R
@@ -227,7 +227,11 @@ normalizeOnFulfilled <- function(onFulfilled) {
     onFulfilled
   } else if (arg_count > 0) {
     function(value, .visible) {
-      onFulfilled(value)
+      if (isTRUE(.visible)) {
+        onFulfilled(value)
+      } else {
+        onFulfilled(invisible(value))
+      }
     }
   } else {
     function(value, .visible) {

--- a/man/is.promise.Rd
+++ b/man/is.promise.Rd
@@ -29,6 +29,6 @@ otherwise.
 \description{
 Use \code{is.promise} to determine whether an R object is a promise. Use
 \code{as.promise} (an S3 generic method) to attempt to coerce an R object to a
-promise. This package includes support for converting \link[future:Future]{future::Future}
+promise. This package includes support for converting \link[future:Future-class]{future::Future}
 objects into promises.
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -12,6 +12,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{magrittr}{\code{\link[magrittr]{\%>\%}}, \code{\link[magrittr]{\%T>\%}}}
+  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}, \code{\link[magrittr:tee]{\%T>\%}}}
 }}
 

--- a/revdep/.gitignore
+++ b/revdep/.gitignore
@@ -1,0 +1,2 @@
+data.sqlite
+*.noindex

--- a/tests/testthat/common.R
+++ b/tests/testthat/common.R
@@ -19,7 +19,7 @@ ext_promise <- function() {
 wait_for_it <- function() {
   while (!loop_empty()) {
     run_now()
-    Sys.sleep(0.1)
+    Sys.sleep(0.01)
   }
 }
 

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -38,6 +38,17 @@ describe("then()", {
     expect_error(promise(~resolve(1)) %>% then(10))
     expect_error(promise(~resolve(1)) %>% then(NULL), NA)
   })
+
+  it("honors visibility with no .visible argument", {
+    result <- NULL
+    p <- promise_resolve(invisible(1))$
+      then(function(value) {
+        result <<- withVisible(value)
+      })
+    wait_for_it()
+    expect_identical(result$value, 1)
+    expect_identical(result$visible, FALSE)
+  })
 })
 
 describe("catch()", {

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -48,6 +48,15 @@ describe("then()", {
     wait_for_it()
     expect_identical(result$value, 1)
     expect_identical(result$visible, FALSE)
+
+    result <- NULL
+    p <- promise_resolve(2)$
+      then(function(value) {
+        result <<- withVisible(value)
+      })
+    wait_for_it()
+    expect_identical(result$value, 2)
+    expect_identical(result$visible, TRUE)
   })
 })
 

--- a/tests/testthat/test-visibility.R
+++ b/tests/testthat/test-visibility.R
@@ -1,0 +1,94 @@
+library(testthat)
+
+source("common.R")
+
+describe("visibility", {
+
+  single_fn <- function(value) {
+    info <- withVisible(value)
+    if (info$visible) {
+      info$value
+    } else {
+      invisible(info$value)
+    }
+  }
+  double_fn <- function(value, .visible) {
+    if (.visible) value else invisible(value)
+  }
+
+  # display in block to avoid indent of doom
+  for (add_catch in c("false", "single", "double", "expr")) {
+  for (add_finally in c("false", "expr")) {
+  for (add_then in c("false", "single", "double", "expr")) {
+
+    it(
+      paste0(
+        "survives ", paste0(c(
+          if (add_then != "false") paste0("then-", add_then),
+          if (add_catch != "false") paste0("catch-", add_catch),
+          if (add_finally != "false") paste0("finally-", add_finally),
+          "then"
+        ), collapse = ", ")),
+      {
+
+        p <- promise_resolve(invisible(1))
+
+        p <-
+          switch(add_then,
+            "false" = p,
+            "single" = p %>% then(single_fn),
+            "double" = p %>% then(double_fn),
+            "expr" = p %>% then(~ {
+              info <- withVisible(.)
+              if (info$visible) {
+                info$value
+              } else {
+                invisible(info$value)
+              }
+            })
+          )
+        p <-
+          switch(add_catch,
+            "false" = p,
+            "single" = p %>% catch(single_fn),
+            "double" = p %>% catch(double_fn),
+            "expr" = p %>% catch(~ {})
+          )
+
+        finally_val <- NULL
+        p <-
+          switch(add_finally,
+            "false" = p,
+            "expr" = p %>% finally(~ {
+              finally_val <<- TRUE
+            })
+          )
+
+        extended_val <-
+          p %>%
+          then(function(value, .visible) {
+            list(value = value, visible = .visible)
+          }) %>%
+          extract()
+
+        regular_val <-
+          p %>%
+          then(function(value) {
+            withVisible(value)
+          }) %>%
+          extract()
+
+        if (add_finally != "false") {
+          expect_true(finally_val)
+        }
+
+        expect_identical(extended_val$value, 1)
+        expect_identical(extended_val$visible, FALSE)
+
+        expect_identical(regular_val$value, 1)
+        expect_identical(regular_val$visible, FALSE)
+
+      }
+    )
+  }}}
+})


### PR DESCRIPTION
Fixes https://github.com/rstudio/promises/issues/18
Fixes https://github.com/rstudio/promises/issues/58

If there is only one argument in `onFulfilled`, pass in `invisible(value)` if the value is not `.visible`

(Invisible test fails before fix)