### PR TITLE
Speed bump for rapid `future_promise()` submissions with limited workers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Suggests:
 LinkingTo: later,
     Rcpp
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 promises (development version)
 ==============
 
+* `future_promise()` recevied a speed improvement when submitting many requests with a minimal number of `{future}` workers. If `future_promise()` runs out of available `{future}` workers, then `future_promise()` will preemptively return for the remainder of the current `{later}` execution. While it is possible for `{future}` to finish a job before submitting all of the `future_promise()` requests, the time saved by not asking `{future}`'s worker availablity will be faster overall than if a few jobs were submitted early. (#78)
 
 
 promises 1.2.0.1

--- a/R/utils.R
+++ b/R/utils.R
@@ -209,3 +209,8 @@ promise_reduce <- function(.x, .f, ..., .init) {
 function() {
   purrr::reduce
 }
+
+# Determine if `identical(x, FALSE)`
+is_false <- function(x) {
+  is.logical(x) && length(x) == 1L && !is.na(x) && !x
+}


### PR DESCRIPTION
Found while debugging https://github.com/rstudio/shiny/issues/2196

Reprex app:

```r
library(shiny)
library(future)
# Use `promises::future_promise()` to allow other shiny users to be able to compute.
# Recommended to always use `promises::future_promise()` instead of `future::future()`
library(promises)
# Pick a plan that makes sense for your use case.
# For this example, using `multisession` and max workers = 3
future::plan("multisession", workers = 3)

# Temp work around: https://github.com/rstudio/shiny/issues/3574
options(shiny.deepstacktrace = FALSE)

ui <- fluidPage(
  sliderInput("slider", "Number of items", min = 100, max = 500, value = 500),
  plotOutput("plot")
)

server <- function(input, output, session) {
  output$plot <- renderPlot({
    req(input$slider)

    progress <- Progress$new(session)

    progress$set(message = 'Calculation in progress.')

    # Retrieve `input$slider` outside of `future`
    start <- Sys.time()
    prep <- NULL
    n <- input$slider
    seq_len(n) %>%
      lapply(function(i) {
        promises::future_promise({
          # Do heavy computations in a `future` worker
          data.frame(i = i, pid = Sys.getpid())
        }) %>%
          promises::finally(function() {
            if (is.null(prep)) {
              prep <<- Sys.time()
              message("Prep time: ", prep - start)
            }
            # Update progress bar in the main R session
            progress$inc(1/n, detail = paste('Computating...', i))
          })
      }) %>%
      # Wait for all promises to finish. Return single promise.
      promises::promise_all(.list = .) %>%
      promises::then(function(results) {
        # Extract result and plot in main R session
        plot(do.call(rbind, results))
      }) %>% promises::finally(function() {
        # Close the progress bar.
        # (An `on.exit()` would occur too early)
        progress$close()
        end <- Sys.time()
        message("Total time: ", end - start)
      })
  })
}

shinyApp(ui, server)
```

```
> # With PR
> shiny::runApp("~/parallel_progress/")
ℹ Loading promises

Listening on http://127.0.0.1:3598
Prep time: 1.88346886634827
Total time: 19.9987919330597
^C

> # With `main` branch
> shiny::runApp("~/parallel_progress/")
ℹ Loading promises

Listening on http://127.0.0.1:3598
Prep time: 3.13909196853638
Total time: 21.1707081794739
^C
```

In the demo app, 500 `future_promise()` submissions are created. Once the first 3 jobs have been submitted, the remaining 497 jobs are attempting to ask "Am I able to proceed?" / "Are there any future workers available?". 

Once the workers run out, the answer should stay the same for the remainder of the computation tick. This PR reduces that question count by 496 (497 - 1). 

The value will reset on the next tick. 

While faster in total computation, I believe it could be even faster. I'd like to know what the current loop iteration is, i.e. `loop tick #21`. So that if the loop has a different tick number we could use that information, rather than relying on later::later(delay = 0) to execute.  But if the reset is being done in the beginning of the work queue, then it might be fine.