### PR TITLE
increase magrittr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     later,
     rlang,
     stats,
-    magrittr
+    magrittr (>= 1.5)
 Suggests:
     testthat,
     future (>= 1.21.0),


### PR DESCRIPTION
`%T>%` is exported starting from version `1.5` - without it it is possible to end-up with the following install error:
```
Error: object ‘%T>%’ is not exported by 'namespace:magrittr'
```