### PR TITLE
fix: Align vignette title and index entry title

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -50,18 +50,28 @@ navbar:
       text: Learning
       menu:
       - text: 1. Why use promises?
-        href: articles/motivation.html
+        href: articles/promises_01_motivation.html
       - text: 2. An informal intro to async programming
-        href: articles/intro.html
+        href: articles/promises_02_intro.html
       - text: 3. Working with promises
-        href: articles/overview.html
+        href: articles/promises_03_overview.html
       - text: 4. Launching tasks with future
-        href: articles/futures.html
+        href: articles/promises_04_futures.html
       - text: 5. Advanced future and promises usage
-        href: articles/future_promise.html
+        href: articles/promises_05_future_promise.html
       - text: 6. Using promises with Shiny
-        href: articles/shiny.html
+        href: articles/promises_06_shiny.html
       - text: 7. Combining promises
-        href: articles/combining.html
+        href: articles/promises_07_combining.html
       - text: "8. Case study: Converting a Shiny app to async"
-        href: articles/casestudy.html
+        href: articles/promises_08_casestudy.html
+
+redirects:
+  - ["articles/motivation.html", "articles/promises_01_motivation.html"]
+  - ["articles/intro.html", "articles/promises_02_intro.html"]
+  - ["articles/overview.html", "articles/promises_03_overview.html"]
+  - ["articles/futures.html", "articles/promises_04_futures.html"]
+  - ["articles/future_promise.html", "articles/promises_05_future_promise.html"]
+  - ["articles/shiny.html", "articles/promises_06_shiny.html"]
+  - ["articles/combining.html", "articles/promises_07_combining.html"]
+  - ["articles/casestudy.html", "articles/promises_08_casestudy.html"]

--- a/vignettes/promises_01_motivation.Rmd
+++ b/vignettes/promises_01_motivation.Rmd
@@ -1,9 +1,9 @@
 ---
-title: "Why use `promises`?"
+title: "Why use promises?"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteIndexEntry{1. Why use promises?}
+  %\VignetteIndexEntry{Why use promises?}
   %\VignetteEncoding{UTF-8}
 ---
 

--- a/vignettes/promises_02_intro.Rmd
+++ b/vignettes/promises_02_intro.Rmd
@@ -3,7 +3,7 @@ title: "An informal introduction to async programming"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteIndexEntry{2. An informal introduction to async programming}
+  %\VignetteIndexEntry{An informal introduction to async programming}
   %\VignetteEncoding{UTF-8}
 ---
 

--- a/vignettes/promises_03_overview.Rmd
+++ b/vignettes/promises_03_overview.Rmd
@@ -1,9 +1,9 @@
 ---
-title: "Working with `promises` in R"
+title: "Working with promises in R"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteIndexEntry{3. Working with promises in R}
+  %\VignetteIndexEntry{Working with promises in R}
   %\VignetteEncoding{UTF-8}
 ---
 

--- a/vignettes/promises_04_futures.Rmd
+++ b/vignettes/promises_04_futures.Rmd
@@ -1,9 +1,9 @@
 ---
-title: "Launching tasks with `future`"
+title: "Launching tasks with future"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteIndexEntry{4. Launching tasks with future}
+  %\VignetteIndexEntry{Launching tasks with future}
   %\VignetteEncoding{UTF-8}
 ---
 

--- a/vignettes/promises_05_future_promise.Rmd
+++ b/vignettes/promises_05_future_promise.Rmd
@@ -1,9 +1,9 @@
 ---
-title: "Advanced `future` and `promises` usage"
+title: "Advanced future and promises usage"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteIndexEntry{5. Advanced future and promises usage}
+  %\VignetteIndexEntry{Advanced future and promises usage}
   %\VignetteEncoding{UTF-8}
 resource_files:
   - future_promise/future.png

--- a/vignettes/promises_06_shiny.Rmd
+++ b/vignettes/promises_06_shiny.Rmd
@@ -1,9 +1,9 @@
 ---
-title: "Using `promises` with Shiny"
+title: "Using promises with Shiny"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteIndexEntry{6. Using promises with Shiny}
+  %\VignetteIndexEntry{Using promises with Shiny}
   %\VignetteEncoding{UTF-8}
 ---
 

--- a/vignettes/promises_07_combining.Rmd
+++ b/vignettes/promises_07_combining.Rmd
@@ -1,9 +1,9 @@
 ---
-title: "Combining `promises`"
+title: "Combining promises"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteIndexEntry{7. Combining promises}
+  %\VignetteIndexEntry{Combining promises}
   %\VignetteEncoding{UTF-8}
 ---
 

--- a/vignettes/promises_08_casestudy.Rmd
+++ b/vignettes/promises_08_casestudy.Rmd
@@ -3,7 +3,7 @@ title: "Case study: converting a Shiny app to async"
 author: Joe Cheng (joe@rstudio.com)
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{8. Case study}
+  %\VignetteIndexEntry{Case study: converting a Shiny app to async}
   %\VignetteEncoding{UTF-8}
   %\VignetteEngine{knitr::rmarkdown}
 ---


### PR DESCRIPTION
Aligns the vignette index entry title with the vignette title to avoid errors thrown by checks.

The vignette entries are sorted by file name rather than by the index entry, so we an oddly out-of-order vignette index anyway. And of course you're not allowed to start a vignette file name with a number, so we're now using `promises_0N_{slug}.Rmd` for the file name. I added pkgdown redirects as well.

## Before

![image](https://github.com/rstudio/promises/assets/5420529/0b427213-d5ae-4b76-9329-f93e2734aa7f)


## After

![image](https://github.com/rstudio/promises/assets/5420529/dd393abb-104d-461a-80b3-9f675642d877)
