### PR TITLE
Fix ever-growing call stacks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# promises (under development)
+
+* Fixed bug introduced in 1.3.1, where promise domains that are active at promise resolution time stay active during handler callback, even if they weren't active when the handler was registered. This was causing stack overflow for long promise chains with many active promise domains. (#115)
+
+
 # promises 1.3.1
 
 * Fixed bug where promise domains were forgotten when handlers were registered from within other handlers. (#110)

--- a/tests/testthat/test-cpp.R
+++ b/tests/testthat/test-cpp.R
@@ -17,9 +17,10 @@ describe("C++ interface", {
       }) %...>%
         {
           expect_identical(., 2)
+          expect_identical(cd$counts$onFulfilledCalled, 1L)
           promise_resolve(TRUE) %...>% {
             expect_true(!is.null(current_promise_domain()))
-            expect_identical(cd$counts$onFulfilledCalled, 3L)
+            expect_identical(cd$counts$onFulfilledCalled, 2L)
           }
         } %>%
         wait_for_it()

--- a/tests/testthat/test-domains.R
+++ b/tests/testthat/test-domains.R
@@ -169,4 +169,48 @@ describe("Promise domains", {
     expect_identical(x, 2L)
 
   })
+
+  it("doesn't grow the call stack", {
+    # See https://github.com/rstudio/promises/issues/114
+    # and also https://github.com/jcheng5/shinychat/issues/16
+
+    recursive_promise <- function(n, .last_callstack_depth = NULL) {
+      if (n == 0) {
+        return(0)
+      } else {
+        promise_resolve(TRUE) %...>% {
+          current_callstack_depth <- length(sys.calls())
+          if (!is.null(.last_callstack_depth)) {
+            expect_identical(current_callstack_depth, .last_callstack_depth)
+          }
+
+          recursive_promise(n - 1, .last_callstack_depth = current_callstack_depth)
+        }
+      }
+    }
+
+    cd <- create_counting_domain()
+    with_promise_domain(cd, {
+      recursive_promise(5) %...>%
+        {
+          # 5 (from inside recursive_promise) + 1 (for the current handler)
+          expect_identical(cd$counts$onFulfilledCalled, 6L)
+        } %>%
+        wait_for_it()
+    })
+
+    cd2 <- create_counting_domain()
+    p <- recursive_promise(5)
+    with_promise_domain(cd2, {
+      p %...>%
+        {
+          # This time, none of the ones inside recursive_promise count, since
+          # they were bound outside of the influence of cd2 (even though they
+          # are resolved within the influence of cd2, thanks to wait_for_it()).
+          expect_identical(cd2$counts$onFulfilledCalled, 1L)
+        } %>%
+        wait_for_it()
+    })
+
+  })
 })


### PR DESCRIPTION
Fixes #114, helps but doesn't totally fix https://github.com/jcheng5/shinychat/issues/16

- Re-entering domains was happening additively, instead of replacing the active domain as it should've been doing.
- Wrapping for re-entering wasn't happening if the domain at the time of binding was NULL. This was incorrect! If the domain was NULL at binding time, and non-NULL at the time of resolution, then the domain needs to be set back to NULL before the handler is invoked!
- Fixed the cpp test that had the wrong value all along
- Added more tests to catch regressions in this area
