### PR TITLE
fix(future): If rejected when checking if resolved, return early

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: promises
 Title: Abstractions for Promise-Based Asynchronous Programming
-Version: 1.3.2.9000
+Version: 1.3.2.9001
 Authors@R: c(
     person("Joe", "Cheng", , "joe@posit.co", role = c("aut", "cre")),
     person("Posit Software, PBC", role = c("cph", "fnd"))
@@ -32,10 +32,10 @@ Suggests:
     spelling,
     testthat,
     vembedr
-LinkingTo: 
+LinkingTo:
     later,
     Rcpp
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Config/Needs/website: rsconnect
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed #122: Use `future::future(..., lazy = TRUE)` to avoid manual capturing of state within `future_promise` (Thank you, @HenrikBengtsson! #123)
 
+* Fixed bug where a `{future}` promise calculation would continue to run even after calling `reject(err)`. (#125)
+
 # promises 1.3.2
 
 * Fixed bug introduced in 1.3.1, where promise domains that are active at promise resolution time stay active during handler callback, even if they weren't active when the handler was registered. This was causing stack overflow for long promise chains with many active promise domains. (#115)

--- a/R/promise.R
+++ b/R/promise.R
@@ -465,8 +465,10 @@ as.promise.Future <- function(x) {
         future::resolved(x, timeout = 0)
       }, FutureError = function(e) {
          reject(e)
-         TRUE
+         NULL
       })
+      if (is.null(is_resolved)) return()
+      
       if (is_resolved) {
         tryCatch(
           {
@@ -474,7 +476,6 @@ as.promise.Future <- function(x) {
             resolve(result)
           }, FutureError = function(e) {
             reject(e)
-            TRUE
           }, error = function(e) {
             reject(e)
           }


### PR DESCRIPTION
If `reject(e)` has been called within the error handler, return early and do not call `future::value(x)` or attempt other return calls

cc @HenrikBengtsson 