### PR TITLE
Adds mirai to documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
 Suggests:
     future (>= 1.21.0),
     knitr,
+    mirai,
     purrr,
     rmarkdown,
     spelling,

--- a/R/promise.R
+++ b/R/promise.R
@@ -413,7 +413,8 @@ promise_reject <- function(reason) {
 #' Use `is.promise` to determine whether an R object is a promise. Use
 #' `as.promise` (an S3 generic method) to attempt to coerce an R object to a
 #' promise, and `is.promising` (another S3 generic method) to test whether
-#' `as.promise` is supported. This package includes support for converting
+#' `as.promise` is supported. [mirai::mirai] objects have an `as.promise` method
+#' defined in the mirai package, and this package provides one for converting
 #' [future::Future] objects into promises.
 #'
 #' @param x An R object to test or coerce.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -8,6 +8,7 @@ Globals
 Hadley’s
 JS
 Lopp
+mirai
 Multisession
 NSE
 OpenCPU

--- a/man/is.promise.Rd
+++ b/man/is.promise.Rd
@@ -30,6 +30,7 @@ otherwise.
 Use \code{is.promise} to determine whether an R object is a promise. Use
 \code{as.promise} (an S3 generic method) to attempt to coerce an R object to a
 promise, and \code{is.promising} (another S3 generic method) to test whether
-\code{as.promise} is supported. This package includes support for converting
+\code{as.promise} is supported. \link[mirai:mirai]{mirai::mirai} objects have an \code{as.promise} method
+defined in the mirai package, and this package provides one for converting
 \link[future:Future-class]{future::Future} objects into promises.
 }


### PR DESCRIPTION
Towards #131.

This is a PR to amend the function docs in promises, and hence very limited in scope.

I will be raising another more substantive PR which updates the vignettes, but posting this first as we may have more discussion/amendments on that one.

FYI the `future_promise()` tests are also failing on main for MacOS R4.5.1 and I'm not sure if this is also related to the regressions in future.