### PR TITLE
Update examples for mirai

### DIFF
--- a/R/pipe.R
+++ b/R/pipe.R
@@ -40,15 +40,14 @@ magrittr::"%T>%"
 #'
 #' @examples
 #' \dontrun{
-#' library(future)
-#' plan(multisession)
+#' library(mirai)
 #'
-#' future_promise(cars) %...>%
+#' mirai(cars) %...>%
 #'   head(5) %...T>%
 #'   print()
 #'
 #' # If the read.csv fails, resolve to NULL instead
-#' future_promise(read.csv("http://example.com/data.csv")) %...!%
+#' mirai(read.csv("http://example.com/data.csv")) %...!%
 #'   { NULL }
 #' }
 #'

--- a/man/pipes.Rd
+++ b/man/pipes.Rd
@@ -56,15 +56,14 @@ function instead of an expression.
 }
 \examples{
 \dontrun{
-library(future)
-plan(multisession)
+library(mirai)
 
-future_promise(cars) \%...>\%
+mirai(cars) \%...>\%
   head(5) \%...T>\%
   print()
 
 # If the read.csv fails, resolve to NULL instead
-future_promise(read.csv("http://example.com/data.csv")) \%...!\%
+mirai(read.csv("http://example.com/data.csv")) \%...!\%
   { NULL }
 }
 


### PR DESCRIPTION
Towards #131. Converts one example from `future_promise()` to `mirai()` that I missed in #132.