### PR TITLE
Update vignettes for mirai

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -45,9 +45,11 @@ navbar:
         href: articles/promises_02_intro.html
       - text: 3. Working with promises
         href: articles/promises_03_overview.html
-      - text: 4. Launching tasks with future
+      - text: 4. Launching tasks with mirai
+        href: articles/promises_04__mirai.html
+      - text: 5a. Launching tasks with future
         href: articles/promises_04_futures.html
-      - text: 5. Advanced future and promises usage
+      - text: 5b. Advanced future and promises usage
         href: articles/promises_05_future_promise.html
       - text: 6. Using promises with Shiny
         href: articles/promises_06_shiny.html
@@ -60,6 +62,7 @@ redirects:
   - ["articles/motivation.html", "articles/promises_01_motivation.html"]
   - ["articles/intro.html", "articles/promises_02_intro.html"]
   - ["articles/overview.html", "articles/promises_03_overview.html"]
+  - ["articles/mirai.html", "articles/promises_04__mirai.html"]
   - ["articles/futures.html", "articles/promises_04_futures.html"]
   - ["articles/future_promise.html", "articles/promises_05_future_promise.html"]
   - ["articles/shiny.html", "articles/promises_06_shiny.html"]

--- a/index.md
+++ b/index.md
@@ -28,22 +28,25 @@ Async programming can require a serious mental shift, even for veteran programme
 
 A more thorough exploration of the concepts behind `promises`, and the API provided by the `promises` package.
 
-#### [4. Launching tasks](articles/futures.html)
+#### [4. Launching tasks](articles/mirai.html)
 
-A guide to the `future` package, the place where we expect most async programming in R to begin.
+A guide to the `mirai` package, the place where we expect most async programming in R to begin.
 
-#### [5. Advance `future` and `promises` usage](articles/future_promise.html)
+#### [5a. Launching tasks with `future`](articles/futures.html)
+#### [5b. Advance `future` and `promises` usage](articles/future_promise.html)
+
+A guide to the `future` package, an alternative that pre-dates `mirai` and used to be the main method for async programming.
 
 Leverage `promises` to make sure that `future` execution does not block the main R process.
 
-#### [5. Using promises with Shiny](articles/shiny.html)
+#### [6. Using promises with Shiny](articles/shiny.html)
 
 Learn how to integrate `promises` into your Shiny applications.
 
-#### [6. Combining `promises`](articles/combining.html)
+#### [7. Combining `promises`](articles/combining.html)
 
 Functions and techniques for working with multiple `promises` simultaneously.
 
-#### [7. Case study: converting a Shiny app to async](articles/casestudy.html)
+#### [8. Case study: converting a Shiny app to async](articles/casestudy.html)
 
 Walk through the conversion of a realistic Shiny example app to async.

--- a/vignettes/promises_02_intro.Rmd
+++ b/vignettes/promises_02_intro.Rmd
@@ -50,17 +50,17 @@ would kick off the CSV reading operation, but then return immediately, long
 before the real work has actually completed.
 
 ```r
-library(future)
-plan(multisession)
+library(mirai)
 
 read.csv.async <- function(file, header = TRUE, stringsAsFactors = FALSE) {
-  future_promise({
-    read.csv(file, header = header, stringsAsFactors = stringsAsFactors)
-  })
+  mirai(
+    read.csv(file, header = header, stringsAsFactors = stringsAsFactors),
+    .args = environment()
+  )
 }
 ```
 
-(Don't worry about what this definition means for now. You'll learn more about defining async functions in [Launching tasks](promises_04_futures.html) and [Advanced `future` and `promises` usage](promises_05_future_promise.html).)
+(Don't worry about what this definition means for now. You'll learn more about defining async functions in [Launching tasks](promises_04__mirai.html).)
 
 **So instead of “read this CSV file” it’s more like “begin reading this CSV
 file”?**
@@ -318,7 +318,7 @@ with some additional functions for working with promises.
 
 So far, the only actual async function we’ve talked about has been
 `read.csv.async`, which doesn’t actually exist. To learn where actual async
-functions come from, read [this guide to the `future` package](promises_04_futures.html).
+functions come from, read this guide to the [`mirai` package](promises_04__mirai.html).
 
 There are the lower-level functions `then`, `catch`, and `finally`, which are
 the non-pipe, non-operator equivalents of the promise operators we’ve been

--- a/vignettes/promises_03_overview.Rmd
+++ b/vignettes/promises_03_overview.Rmd
@@ -54,10 +54,10 @@ So if a regular, synchronous function call generally looks like this:
 value <- read.csv("http://example.com/data/data.csv")
 ```
 
-An asynchronous function call (which uses [the future package](promises_04_futures.html) via [`future_promise()`](promises_05_future_promise.html)) will look instead like:
+An asynchronous function call (which uses [the mirai package](promises_04__mirai.html)) will look instead like:
 
 ```r
-promise <- future_promise(read.csv("http://example.com/data/data.csv"))
+promise <- as.promise(mirai(read.csv("http://example.com/data/data.csv")))
 ```
 
 While the regular function call returns a data frame, the async call returns a promise, which is most definitely not a data frame. You cannot ask the promise how many rows it has, or the names of its columns. You cannot run dplyr operations on it, or turn it into a data.table.
@@ -261,7 +261,7 @@ So the equivalent to this (synchronous) code:
 
 ```r
 value <- tryCatch(
-  operation(),
+  pkg::operation(),
   error = function(err) {
     warning("An error occurred: ", err)
     warning("Using default value of 0 instead")
@@ -273,7 +273,7 @@ value <- tryCatch(
 would be this, when the operation is performed asynchronously:
 
 ```r
-promise <- future_promise(operation()) %>%
+promise <- mirai(pkg::operation()) %>%
   then(onRejected = function(err) {
     warning("An error occurred: ", err)
     warning("Using default value of 0 instead")
@@ -302,21 +302,21 @@ Well, `then` has its own default version of `onRejected`. It’s *not* an empty 
 The same syntactic sugar that is offered for non-error cases, is available for error handling code as well. You can use formulas in `onRejected`:
 
 ```r
-future_promise(operation()) %>%
+mirai(pkg::operation()) %>%
   then(onRejected = ~warning(.))
 ```
 
 There’s an error handling pipe operator `%...!%`, that works similar to `%...>%` but it binds to `then(onRejected)` instead of `then(onFulfilled)`:
 
 ```r
-future_promise(operation()) %...!%
+mirai(pkg::operation()) %...!%
   warning()
 ```
 
 There’s also a `catch()` function that is just a shorthand for `then(onRejected)`. It saves a little typing, but more importantly, is easier to read:
 
 ```r
-future_promise(operation()) %>%
+mirai(pkg::operation()) %>%
   catch(warning)
 ```
 
@@ -352,12 +352,15 @@ In synchronous programming, you use either`tryCatch(expr, finally = ...)` or `on
 ```r
 file_path <- tempfile(fileext = ".png")
 png_bytes <-
-  future_promise({
-    png(file_path)
-    plot(cars)
-    dev.off()
-    file_path
-  }) %...>%
+  as.promise(mirai(
+    {
+      png(file_path)
+      plot(cars)
+      dev.off()
+      file_path
+    },
+    file_path = file_path
+  )) %...>%
   readBin(raw(), size = file.info(file_path)$size) %>%
   finally(~unlink(file_path))
 ```
@@ -365,5 +368,5 @@ png_bytes <-
 In this example, we need a temp file for the duration of the pipeline. Our `finally` makes sure the temp file is deleted when the operation is done, regardless of whether it succeeded or failed.
 
 <div style="font-size: 20px; margin-top: 40px; text-align: right;">
-Next: [Launching tasks](promises_04_futures.html)
+Next: [Launching tasks](promises_04__mirai.html)
 </div>

--- a/vignettes/promises_04__mirai.Rmd
+++ b/vignettes/promises_04__mirai.Rmd
@@ -1,0 +1,145 @@
+---
+title: "Launching tasks with mirai"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteIndexEntry{Launching tasks with mirai}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{css echo=FALSE}
+.alert-secondary a, .alert-secondary a:visited {
+  color: inherit;
+  text-decoration: underline;
+}
+.alert code {
+  color: inherit;
+  background-color: inherit;
+}
+```
+
+The `mirai` package provides a lightweight way to launch R tasks that don't block the current R session.
+
+The `promises` package provides the API for working with the results of async tasks, but it totally abdicates responsibility for actually launching/creating async tasks. The idea is that any number of different packages could be capable of launching async tasks, using whatever techniques they want, but all of them would either return promise objects (or objects that can be converted to promise objects, as is the case for `mirai`).
+
+This document will give an introduction to the parts of `mirai` that are most relevant to promises. For more information, please consult the documentation and vignettes that come with (`mirai`)[https://mirai.r-lib.org].
+
+## How mirai works
+
+The main API that `mirai` provides couldn't be simpler. You call `mirai()` and pass it the code that you want executed asynchronously:
+
+```R
+m <- mirai({
+  # expensive operations go here...
+  df <- download_lots_of_data()
+  fit_model(df)
+})
+```
+
+The object that's returned is a mirai, which for all intents and purposes is a promise object[^1], which will eventually resolve to the return value of the code block (i.e. the last expression) or an error if the code does not complete executing successfully. The important thing is that no matter how long the expensive operation takes, these lines will execute almost instantly, while the operation continues in the background.
+
+[^1]: (The `mirai` package provides several functions for working with mirai objects, but they are not relevant for our purposes.)
+
+But we know that R is single-threaded, so how does `mirai` accomplish this? The answer: by utilizing another R process. `mirai` delegates the execution of the expensive operation to a totally different R process, so that the original R process can move on.
+
+## Choosing a launch method
+
+In mirai, the `daemons()` function is used to set and launch background R processes (*daemons*).
+
+These background processes will be used/recycled for the life of the originating R process. If a mirai is launched while all the background R processes are busy executing, then the new mirai is queued until one of the background processes frees up.
+
+To launch `n` processes locally, you just need to call `daemons(n)`, supplying the value of `n`. 
+
+You need to determine `n` yourself, and typically this should be at most one less than the number of processor cores on your machine, to leave one for the main R process. The reason we don't automatically detect this for you is that you may also be running other tasks on your machine, and you should take this into account when supplying a value for `n`.
+
+`daemons()` has further arguments `url` and `remote` for setting and launching remote daemons over the network for distributed computing. To learn more, see the [`mirai::daemons()` reference docs](https://mirai.r-lib.org/reference/daemons.html) as well as the daemons sections of the [`mirai` reference vignette](https://mirai.r-lib.org/articles/mirai.html).
+
+If you don't set `daemons()` in a session, then each `mirai()` call will launch a new local R process solely for the purpose of performing that evaluation. Whilst this may be desirable in certain circumstances, this is rarely going to be the case for Shiny. This is as we cannot limit the total number of processes spawned at any one time. If a Shiny app has many simultaneous users, then this could lead to an excessive number of processes being created, overwhelming the system.
+
+## Caveats and limitations
+
+The abstractions that `mirai` presents are simple and consistent, although it may take some time to get used to them. Please read this entire section carefully before proceeding.
+
+### Globals: Providing input to mirai code chunks
+
+Most mirai code chunks will need to reference data from the original process, e.g. data to be fitted, URLs to be requested, file paths to read from.
+
+As evaluation happens in another process, these won't be available to the code chunk by default. These objects will need to be passed to the `...` argument of your `mirai()` call. These are then serialized and sent to the other process along with the code to be executed.
+
+These objects include any functions which are defined in your session and not in a package.
+
+For example:
+```R
+download_data <- function(url) {
+  file <- tempfile()
+  download.file(url, file, "libcurl")
+  file
+}
+
+url <- "http://example.com/data.csv"
+
+m <- mirai(
+  {
+    file <- download_data(url)
+    read.csv(file)
+  },
+  download_data = download_data,
+  url = url
+)
+```
+If there are many variables to pass through, mirai does offer a convenience feature to pass an environment instead of individual `...` pairs. The above call would then look like this instead:
+
+```R
+m <- mirai(
+  {
+    file <- download_data(url)
+    read.csv(file)
+  },
+  environment()
+)
+```
+This passes the calling environment, which includes both the `download_data` function as well as `url`.
+
+Care should be taken when using this feature as it will also pass anything else that happens to be in the same environment. It is usually safer to use when mirai is called inside of another function, then `environment()` will only consist of variables passed as arguments to that function, or created locally within it.
+
+### Package loading
+
+Besides variables, package functions need to be declared with the full namespace so that they can be found in the other process. For example, using `dplyr::mutate()` instead of just `mutate()`, even if the `dplyr` package is loaded in your main session, as the other process will not have any packages loaded by default.
+
+Alternatively, make a call to load the package inside your mirai code, for example by adding `library(dplyr)` at the top of your code. Note that for infix operators such as the magrittr pipe `%>%`, this may be the most convenient option. Use of the pipe requires that the package be loaded beforehand using `library(magrittr)`.
+
+### Custom Data Types
+
+Certain objects are implemented at a low level, not using one of R's native vector types, and represented in R by an external pointer. An example of this is an Arrow table. It is not possible to serialize these to and from R's native rds format. Instead they provide their own serialization and deserialization methods.
+
+mirai offers a seamless solution for working with these data types, integrating those custom serialization and deserialization methods with R's native serialization so that you don't need to manually handle each instance of these objects when moving them across processes.
+
+This does require a one-off configuration step when you set up daemons, and you may read more about this in the [`mirai` serialization vignette](https://mirai.r-lib.org/articles/mirai-serialization.html).
+
+### Native resources
+
+Mirai code blocks cannot use resources such as database connections and network sockets that were created in the parent process. Even if it seems to work with a simple test, you are asking for crashes or worse by sharing these kinds of resources across processes.
+
+Instead, make sure you create, use, and destroy such resources entirely within the scope of the mirai code block.
+
+### Mutation
+
+Reference class objects (including R6 objects and data.table objects) and environments are among the few "native" R object types that are mutable, that is, can be modified in-place. Unless they contain native resources (see previous section), there's nothing wrong with using mutable objects from within mirai code blocks, even objects created in the parent process. However, note that any changes you make to these objects will not be visible from the parent process; the mirai code is operating on a copy of the object, not the original.
+
+### Returning values
+
+Mirai code blocks return a value—they'd be a lot less useful if they couldn't! Like everywhere else in R, the return value is determined by the last expression in the code block, unless `return()` is explicitly called earlier.
+
+The return value will always be copied back into the parent process. This matters for two reasons.
+
+First, if the return value is very large, the copying process can take some time — and because the data must essentially be serialized to and deserialized from rds format, it can take a surprising amount of time. In the case of mirai blocks that execute fairly quickly but return huge amounts of data, you may be better off not using async techniques at all.
+
+Second, objects that refer to native resources are unlikely to work in this direction either; just as you can't use the parent's database connections in the child process, you also cannot have the child process return a database connection for the parent to use.
+
+<div style="font-size: 20px; margin-top: 40px; text-align: right;">
+
+Next:
+
+* [Using `promises` with Shiny](promises_06_shiny.html)
+
+</div>

--- a/vignettes/promises_04_futures.Rmd
+++ b/vignettes/promises_04_futures.Rmd
@@ -19,14 +19,13 @@ vignette: >
 ```
 
 <div class="alert alert-secondary">
-While this article and others on this site focus on the `future` package, there's a much newer package called [`mirai`](https://mirai.r-lib.org/) that you may want to consider instead.
+While this article focuses on the `future` package, you may wish to consider the newer [`mirai`](promises_04__mirai.html) package, which didn't exist when this article was first written.
 Here are some factors to consider as you choose between the two.
 
-1. The `future` package tries hard to automatically infer what variables and packages you need from the main R package, and makes those available to the child process. `mirai` doesn't try to do this for you; you need to pass in whatever data you need explicitly, and make package-namespaced calls explicitly inside of your inner code.
-2. `mirai` is very fast; it's much faster than `future` at starting up and has less per-task overhead. `mirai` creates event-driven promises, whereas promises using `future` time-poll every 0.1 seconds. This makes `mirai` ideal where response times and latency are critical.
-3. `future` is designed to be a general API supporting many types of distributed computing backends, and potentially offers more options. `mirai` on the other hand is its own system, whilst it does support both local and distributed execution.
-4. `mirai` is inherently queued, meaning it readily accepts more tasks than workers. This means you don’t need an equivalent of `future_promise()`. With `future` you need to manage cases where futures launch other futures ("evaluation topologies") upfront, whereas with `mirai` they will just work.
-5. `mirai` supports task cancellation and the ability to interrupt ongoing tasks on the worker.
+1. The `future` package tries hard to automatically infer what variables and packages you need from the main R session, and makes those available to the child process. `mirai` doesn't try to do this for you; you need to pass in whatever data you need explicitly, and namespace package function calls within your code.
+2. `mirai` is very fast; it's much faster than `future` at starting up and has less per-task overhead. `mirai` creates event-driven promises, whereas promises using `future` time-poll every 0.1 seconds. This makes `mirai` much better-suited to situations where response times and latency are critical.
+3. `future` is designed to be a general API, and supports distributed computing backends provided by other packages. `mirai` on the other hand provides integrated launchers for high-performance computing clusters and any computer reachable via SSH.
+4. `mirai` is designed as an async framework and is inherently queued, meaning it readily accepts more tasks than workers. This means the distinction between `future()` and `future_promise()` doesn't exist for mirai.
 </div>
 
 The `future` package provides a lightweight way to launch R tasks that don't block the current R session. It was created by Henrik Bengtsson long before the `promises` package existed—the first CRAN release of `future` predates development of `promises` by almost two years.
@@ -106,13 +105,11 @@ First, if the return value is very large, the copying process can take some time
 
 Second, objects that refer to native resources are unlikely to work in this direction either; just as you can't use the parent's database connections in the child process, you also cannot have the child process return a database connection for the parent to use.
 
-<div style="display:flex;">
-  <div style="font-size: 20px; margin-top: 40px; margin-left: auto;">
+<div style="font-size: 20px; margin-top: 40px; text-align: right;">
 
 Next:
 
 * [Advanced `future` and `promises` usage](promises_05_future_promise.html)
 * [Using `promises` with Shiny](promises_06_shiny.html)
 
-  </div>
 </div>

--- a/vignettes/promises_06_shiny.Rmd
+++ b/vignettes/promises_06_shiny.Rmd
@@ -24,9 +24,9 @@ Async programming with Shiny boils down to following a few steps.
 
 1. Identify slow operations (function calls or blocks of statements) in your app.
 
-2. Convert the slow operation into a future using `future_promise()`. (If you haven't read the [article on futures](promises_04_futures.html) and [`future_promise()`](promises_05_future_promise.html), definitely do that before proceeding!)
+2. Convert the slow operation into a 'mirai' using `mirai()`. (If you haven't read the [article on mirai](promises_04__mirai.html), definitely do that before proceeding!)
 
-3. Any code that relies on the result of that operation (if any), whether directly or indirectly, now must be converted to promise handlers that operate on the future object.
+3. Any code that relies on the result of that operation (if any), whether directly or indirectly, now must be converted to promise handlers that operate on the mirai object.
 
 We'll get into details for all these steps, but first, an example. Consider the following synchronous server code:
 
@@ -44,12 +44,12 @@ We'd convert it to async like this:
 
 ```R
 library(promises)
-library(future)
-plan(multisession)
+library(mirai)
+daemons(6)
 
 function(input, output, session) {
   output$plot <- renderPlot({
-    future_promise({ expensive_operation() }) %...>%
+    mirai({ expensive_operation() }) %...>%
       head(input$n) %...>%
       plot()
   })
@@ -58,56 +58,54 @@ function(input, output, session) {
 
 ## Adding prerequisites
 
-The easiest part is adding `library(promises)`, `library(future)`, and `plan(multisession)` to the top of the app.
+The easiest part is adding `library(promises)`, `library(mirai)`, and `daemons(6)` to the top of the app.
 
 The `promises` library is necessary for the `%...>%` operator. You may also want to use promise utility functions like `promise_all` and `promise_race`.
 
-The `future` library is needed because the `future()` function call used inside `future_promise()` is how you will launch asynchronous tasks.
+The `mirai` library is needed because the `mirai()` function call is how you will launch asynchronous tasks.
 
-`plan(multisession)` is a directive to the `future` package, telling it how future tasks should actually be executed. See the [article on futures](promises_04_futures.html) for more details.
+`daemons(6)` is a directive to the `mirai` package, telling it how mirai tasks should actually be executed. See the [article on mirai](promises_04__mirai.html) for more details.
 
 ## Identifying slow operations
 
-To find areas of your code that are good candidates for the future/promise treatment, let's start with the obvious: identifying the code that is making your app slow. You may assume it's your plotting code that's slow, but it's actually your database queries; or vice versa. If there's one thing that veteran programmers can agree on, it's that human intuition is a surprisingly unreliable tool for spotting performance problems.
+To find areas of your code that are good candidates for the mirai/promise treatment, let's start with the obvious: identifying the code that is making your app slow. You may assume it's your plotting code that's slow, but it's actually your database queries; or vice versa. If there's one thing that veteran programmers can agree on, it's that human intuition is a surprisingly unreliable tool for spotting performance problems.
 
 Our recommendation is that you use the [profvis](https://profvis.r-lib.org/) profiler, which we designed to work with Shiny (see Example 3 in the profvis documentation). You can use profvis to help you focus in on where the time is actually being spent in your app.
 
->  **Note:** As of this writing, profvis doesn't work particularly well for diagnosing performance problems in parts of your code that you've already made asynchronous. In particular, we haven't done any work to help it profile code that executes in a future, and the mechanism we use to hide "irrelevant" parts of the stack trace doesn't work well with promises. These are ripe areas for future development.
+>  **Note:** As of this writing, profvis doesn't work particularly well for diagnosing performance problems in parts of your code that you've already made asynchronous. In particular, we haven't done any work to help it profile code that executes in a mirai, and the mechanism we use to hide "irrelevant" parts of the stack trace doesn't work well with promises. These are ripe areas for future development.
 
-Async programming works well when you can identify just a few "hotspots" in your app where lots of time is being spent. It works much less well if your app is too slow because of a generalized, diffuse slowness through every aspect of your app, where no one operation takes too much time but it all adds up to a lot. The more futures you need to introduce into your app, the more fixed communication overhead you incur. So for the most bang-for-the-buck, we want to launch a small number of futures per session but move a lot of the waited-on code into each one.
+Async programming works well when you can identify just a few "hotspots" in your app where lots of time is being spent. It works much less well if your app is too slow because of a generalized, diffuse slowness through every aspect of your app, where no one operation takes too much time but it all adds up to a lot. The more mirai you need to introduce into your app, the more fixed communication overhead you incur. So for the most bang-for-the-buck, we want to launch a small number of mirai per session but move a lot of the waited-on code into each one.
 
-## Converting a slow operation into a future
+## Converting a slow operation into a mirai
 
-Now that we've found hotspots that we want to make asynchronous, let's talk about the actual work of converting them to futures.
+Now that we've found hotspots that we want to make asynchronous, let's talk about the actual work of converting them to mirai.
 
-Conceptually, futures work like this:
+Conceptually, mirai works like this:
 
 ```R
-future({
+mirai({
   # Expensive code goes here
 }) %...>% (function(result) {
   # Code to handle result of expensive code goes here
 })
 ```
 
-which seems incredibly simple. What's actually happening is that the future runs in a totally separate child R process, and then the result is collected up and returned to the main R process:
+which seems incredibly simple. What's actually happening is that the mirai runs in a totally separate child R process, and then the result is collected up and returned to the main R process:
 
 ```R
 # Code here runs in process A
-future({
+mirai({
   # Code here runs in (child) process B
 }) %...>% (function(result) {
   # Code here runs in process A
 })
 ```
 
-The fact that the future code block executes in a separate process means we have to take special care to deal with a number of practical issues. There are extremely important constraints that futures impose on their code blocks; certain objects cannot be safely used across process boundaries, and some of the default behaviors of the future library may severely impact the performance of your app. Again, see the [article on futures](promises_04_futures.html) for more details.
-
-The remainder of this document will use `future_promise()` in place of `future()`. For more information on the differences, see the [article on the benefits of `future_promise()`](promises_05_future_promise.html).
+The fact that the mirai code block executes in a separate process means we have to take special care to deal with a number of practical issues. All the objects required by the code block must be passed along as part of the `mirai()` function call; certain objects may require custom serialization to be set up, and other objects cannot be safely used across process boundaries. Again, see the [article on mirai](promises_04__mirai.html) for more details.
 
 ### Shiny-specific caveats and limitations
 
-In addition to the constraints that all futures face, there is an additional one for Shiny: reactive values and reactive expressions cannot be read from within a future. Whenever reactive values/expressions are read, side effects are carried out under the hood so that the currently executing observer or reactive expression can be notified when the reactive value/expression becomes invalidated. If a reactive value/expression is created in one process, but read in another process, there will be no way for readers to be notified about invalidation.
+In addition to the constraints that all mirai face, there is an additional one for Shiny: reactive values and reactive expressions cannot be read from within a mirai. Whenever reactive values/expressions are read, side effects are carried out under the hood so that the currently executing observer or reactive expression can be notified when the reactive value/expression becomes invalidated. If a reactive value/expression is created in one process, but read in another process, there will be no way for readers to be notified about invalidation.
 
 This code, for example, will not work:
 
@@ -116,14 +114,14 @@ function(input, output, session) {
   r1 <- reactive({ ... })
 
   r2 <- reactive({
-    future_promise({
+    mirai({
       r1() # Will error--don't do this!
-    })
+    }, r1 = r1)
   })
 }
 ```
 
-Even though `r1()` is called from inside the `r2` reactive expression, the fact that it's also in a future means the call will fail. Instead, you must read any reactive values/expressions you need in advance of launching the future:
+Even though `r1()` is called from inside the `r2` reactive expression, the fact that it's also in a mirai means the call will fail. Instead, you must read any reactive values/expressions you need in advance of launching the mirai:
 
 ```R
 function(input, output, session) {
@@ -131,9 +129,9 @@ function(input, output, session) {
 
   r2 <- reactive({
     val <- r1()
-    future_promise({
+    mirai({
       val # No problem!
-    })
+    }, val = val)
   })
 }
 ```
@@ -145,7 +143,7 @@ function(input, output, session) {
   r1 <- reactive({ ... })
 
   r2 <- reactive({
-    future_promise({ ... }) %...>%
+    mirai({ ... }) %...>%
       rbind(r1()) # OK!
   })
 }
@@ -172,7 +170,7 @@ could become:
 
 ```R
 output$table <- renderTable({
-  future_promise({ read.csv(url) }) %...>%
+  mirai(read.csv(url), url = url) %...>%
     filter(date == input$date)
 })
 ```
@@ -182,9 +180,9 @@ or, trading elegance for efficiency:
 ```R
 output$table <- renderTable({
   input_date <- input$date
-  future_promise({
+  mirai({
     read.csv(url) %>% filter(date == input_date)
-  })
+  }, url = url, input_date = input_date)
 })
 ```
 
@@ -194,22 +192,22 @@ The important thing to keep in mind is that the promise (or promise pipeline) mu
 
 The render functions `renderPrint()` and `renderPlot()` are slightly different than other render functions, in that they can be affected by side effects in the code block you provide. In `renderPrint` you can print to the console, and in `renderPlot` you can plot to the active R graphics device.
 
-With promises, these render functions can work in a similar way, but with a caveat. As you hopefully understand by now, futures execute their code in a separate R process, and printing/plotting in a separate process won't have any effect on the Shiny output in the original process. These examples, then, are incorrect:
+With promises, these render functions can work in a similar way, but with a caveat. As you hopefully understand by now, mirai execute their code in a separate R process, and printing/plotting in a separate process won't have any effect on the Shiny output in the original process. These examples, then, are incorrect:
 
 ```R
 output$summary <- renderPrint({
-  future_promise({
+  mirai({
     read.csv(url) %>%
       summary() %>%
       print()
-  })
+  }, environment())
 })
 
 output$plot <- renderPlot({
-  future_promise({
+  mirai({
     df <- read.csv(url)
     ggplot(df, aes(length, width)) + geom_point()
-  })
+  }, environment())
 })
 ```
 
@@ -217,13 +215,13 @@ Instead, do printing and plotting after control returns back to the original pro
 
 ```R
 output$summary <- renderPrint({
-  future_promise({ read.csv(url) }) %...>%
+  mirai(read.csv(url), url = url) %...>%
     summary() %...>%
     print()
 })
 
 output$plot <- renderPlot({
-  future_promise({ read.csv(url) }) %...>%
+  mirai(read.csv(url), url = url) %...>%
   {
     ggplot(., aes(length, width)) + geom_point()
   }
@@ -257,17 +255,17 @@ data <- reactiveVal(readRDS("cached.rds"))
 
 function(input, output, session) {
   observeEvent(input$refresh_data, {
-    future_promise({
+    mirai({
       df <- read.csv(url)
       saveRDS(df, "cached.rds")
       df
-    }) %...>%
+    }, url = url) %...>%
       data()
   })
 }
 ```
 
-Note that in this version, we cannot call `data(df)` inside the future, as this would cause the update to happen in the wrong process. Instead, we use the `%...>%` operator to perform the assignment back in the main process once the future resolves.
+Note that in this version, we cannot call `data(df)` inside the mirai, as this would cause the update to happen in the wrong process. Instead, we use the `%...>%` operator to perform the assignment back in the main process once the mirai resolves.
 
 ### Reactive expressions
 
@@ -298,7 +296,7 @@ And now in async:
 ```R
 function(input, output, session) {
   data <- eventReactive(input$refresh_data, {
-    future_promise({ read.csv(url) })
+    mirai(read.csv(url), url = url)
   })
 
   filteredData <- reactive({

--- a/vignettes/promises_07_combining.Rmd
+++ b/vignettes/promises_07_combining.Rmd
@@ -29,11 +29,10 @@ Here's an example using `promise_all` to combine the results of two async `read.
 
 ```r
 library(promises)
-library(future)
-plan(multisession)
+library(mirai)
 
-a <- future_promise(read.csv("a.csv"))
-b <- future_promise(read.csv("b.csv"))
+a <- mirai(read.csv("a.csv"))
+b <- mirai(read.csv("b.csv"))
 
 result <- promise_all(a = a, b = b) %...>% {
   rbind(.$a, .$b)
@@ -46,11 +45,10 @@ The `.$` prefix is a bit inelegant, so we recommend the use of the base R functi
 
 ```r
 library(promises)
-library(future)
-plan(multisession)
+library(mirai)
 
-a <- future_promise(read.csv("a.csv"))
-b <- future_promise(read.csv("b.csv"))
+a <- mirai(read.csv("a.csv"))
+b <- mirai(read.csv("b.csv"))
 
 promise_all(a = a, b = b) %...>%
   with({
@@ -70,13 +68,12 @@ Gathering is easy and convenient, but sometimes not flexible enough. For example
 
 ```r
 library(promises)
-library(future)
-plan(multisession)
+library(mirai)
 
-a <- future_promise(1)
+a <- mirai(1)
 
 a %...>% (function(a) {
-  b <- future_promise(2)
+  b <- mirai(2)
   b %...>% (function(b) {
     a + b
   })
@@ -91,11 +88,10 @@ The nesting pattern is effective and flexible. The main downside is the physical
 
 ```r
 library(promises)
-library(future)
-plan(multisession)
+library(mirai)
 
-a <- future_promise({ Sys.sleep(1); 1 })
-b <- future_promise({ Sys.sleep(0.5); 2 })
+a <- mirai({ Sys.sleep(1); 1 })
+b <- mirai({ Sys.sleep(0.5); 2 })
 
 first <- promise_race(a, b)
 ```
@@ -114,14 +110,14 @@ In the example below, we iterate over a named vector of package names. For each 
 
 ```r
 library(promises)
-library(future)
-plan(multisession)
+library(mirai)
 
 get_pub_date <- function(pkg) {
   desc_url <- paste0("https://cran.r-project.org/web/packages/", pkg, "/DESCRIPTION")
-  future_promise({
-    read.dcf(url(desc_url))[, "Date/Publication"] %>% unname()
-  })
+  mirai({
+    r <- read.dcf(url(desc_url))[, "Date/Publication"]
+    unname(r)
+  }, desc_url = desc_url)
 }
 
 packages <- setNames(, c("ggplot2", "dplyr", "knitr"))
@@ -135,13 +131,13 @@ The resulting output looks like this:
 
 ```
 $ggplot2
-[1] "2016-12-30 22:45:17"
+[1] "2025-04-09 09:40:10 UTC"
 
 $dplyr
-[1] "2017-09-28 20:43:29 UTC"
+[1] "2023-11-17 16:50:02 UTC"
 
 $knitr
-[1] "2018-01-29 11:01:22 UTC"
+[1] "2025-03-16 09:20:02 UTC"
 ```
 
 `promise_map` works serially; each time it calls the given function on an element of the list/vector, it will wait for the returned promise to resolve before proceeding to the next element. Furthermore, any error or rejected promise will cause the entire `promise_map` operation to reject.
@@ -173,8 +169,7 @@ The following example loops through a partial list of CRAN mirrors, returning th
 
 ```r
 library(promises)
-library(future)
-plan(multisession)
+library(mirai)
 
 cran_mirrors <- c(
   "https://cloud.r-project.org",
@@ -187,10 +182,10 @@ promise_reduce(cran_mirrors, function(result, mirror) {
   if (!is.null(result)) {
     result
   } else {
-    future_promise({
+    mirai({
       # Test the URL; return the URL on success, or NULL on failure
       if (!httr::http_error(mirror)) mirror
-    })
+    }, mirror = mirror)
   }
 }, .init = NULL) %...>% print()
 ```

--- a/vignettes/promises_08_casestudy.Rmd
+++ b/vignettes/promises_08_casestudy.Rmd
@@ -8,7 +8,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-In this case study, we'll work through an application of reasonable complexity, turning its slowest operations into futures/promises and modifying all the downstream reactive expressions and outputs to deal with promises.
+In this case study, we'll work through an application of reasonable complexity, turning its slowest operations into mirai/promises and modifying all the downstream reactive expressions and outputs to deal with promises.
 
 ## Motivation
 
@@ -148,12 +148,12 @@ In that sense, the cranwhales app isn't a perfect example, because it has lots o
 To quote the article [*Using promises with Shiny*](https://rstudio.github.io/promises/articles/shiny.html), async programming with Shiny boils down to following a few steps:
 
 1. Identify slow operations in your app.
-2. Convert the slow operations into futures.
-3. Any code that relies on the result of those operations (if any), whether directly or indirectly, now must be converted to promise handlers that operate on the future object.
+2. Convert the slow operations into mirai.
+3. Any code that relies on the result of those operations (if any), whether directly or indirectly, now must be converted to promise handlers that operate on the mirai object.
 
 In this case, the slow operations are easy to identify: the downloading and parsing that takes place in the `data` reactive expression can each take several long seconds.
 
-Converting the download and parsing operations into futures turns out to be the most complicated part of the process, for reasons we'll get into later.
+Converting the download and parsing operations into mirai turns out to be the most complicated part of the process, for reasons we'll get into later.
 
 Assuming we do that successfully, the `data` reactive expression will no longer return a data frame, but a `promise` object (that resolves to a data frame). Since the `whales` and `whale_downloads` reactive expressions both rely on `data`, those will both also need to be converted to read and return `promise` objects. And therefore, because the outputs all rely on one or more reactive expressions, they will all need to know how to deal with `promise` objects.
 
@@ -167,21 +167,21 @@ In some cases, these code snippets may be slightly abridged. See the [GitHub rep
 
 Until you've received an introduction to the `%...>%` operator, the async code below will make no sense, so if you haven't read [*An informal intro to async programming*](https://rstudio.github.io/promises/articles/intro.html) and/or [*Working with promises in R*](https://rstudio.github.io/promises/articles/overview.html), I highly recommend doing so before continuing!
 
-### Loading `promises` and `future`
+### Loading `promises` and `mirai`
 
 The first thing we'll do is load the basic libraries of async programming.
 
 ```r
 library(promises)
-library(future)
-plan(multisession)
+library(mirai)
+daemons(6)
 ```
 
-I originally used `multiprocess` but file downloading inside a future seemed to fail on Mac. (I've found that it's usually not worth spending a lot of time trying to figure out why `multiprocess` doesn't work for some specific code; instead, just use `multisession`, since that's probably going to be the solution anyway.)
+The above sets 6 daemons (background processes) on the local machine, but this could also be anything else supported by the `daemons()` function.
 
-### The `data` reactive: future_promise() all the things
+### The `data` reactive: mirai() all the things
 
-The next thing we'll do is convert the `data` event reactive to use `future` for the expensive bits. The original code looks lke this:
+The next thing we'll do is convert the `data` event reactive to use `mirai` for the expensive bits. The original code looks lke this:
 
 ```r
 # SYNCHRONOUS version
@@ -221,20 +221,20 @@ data <- eventReactive(input$date, {
   url <- glue("http://cran-logs.rstudio.com/{year}/{date}.csv.gz")
   path <- file.path("data_cache", paste0(date, ".csv.gz"))
 
-  future_promise({
+  mirai({
     if (!file.exists(path)) {
       download.file(url, path)
     }
     read_csv(path, col_types = "Dti---c-ci", progress = FALSE)
-  })
+  }, path = path, url = url)
 })
 ```
 
-Pretty straightforward. This reactive now returns a future (which counts as a promise), not a data frame.
+Pretty straightforward. This reactive now returns a mirai (which counts as a promise), not a data frame.
 
-Remember that we **must** read any reactive values (including `input`) and reactive expressions [from **outside** the future](https://rstudio.github.io/promises/articles/shiny.html#shiny-specific-caveats-and-limitations). (You will get an error if you attempt to read one from inside the future.)
+Remember that we **must** read any reactive values (including `input`) and reactive expressions [from **outside** the mirai](https://rstudio.github.io/promises/articles/shiny.html#shiny-specific-caveats-and-limitations). (You will get an error if you attempt to read one from inside the mirai.)
 
-At this point, since there are no other long-running operations we want to make asynchronous, we're actually done interacting directly with the `future` package. The rest of the reactive expressions will deal with the future returned by `data` using general async functions and operators from `promises`.
+At this point, since there are no other long-running operations we want to make asynchronous, we're actually done interacting directly with the `mirai` package. The rest of the reactive expressions will deal with the mirai returned by `data` using general async functions and operators from `promises`.
 
 ### The `whales` reactive: simple pipelines are simple
 
@@ -272,9 +272,9 @@ The input (`data()`) is a promise, the resulting output object is a promise, eac
 
 An example this simple may seem reductive, but this best-case scenario happens surprisingly often, if your coding style is influenced by the tidyverse. In this example app, **59%** of the reactives, observers, and outputs were converted using nothing more than replacing `%>%` with `%...>%`.
 
-One last thing before we move on. In the last section, I emphasized that reactive values cannot be read from inside a future. Here, we're using `head(input$count)` inside a promise-pipeline; since `data()` is written using a future, doesn't that mean… well… isn't this wrong?
+One last thing before we move on. In the last section, I emphasized that reactive values cannot be read from inside a mirai. Here, we're using `head(input$count)` inside a promise-pipeline; since `data()` is written using a mirai, doesn't that mean… well… isn't this wrong?
 
-Nope—this code is just fine. The prohibition is against reading reactive values/expressions from *inside* a future, because code inside a future is executed in a totally different R process. The steps in a promise-pipeline aren't futures, but promise handlers. These aren't executed in a different process; rather, they're executed back in the original R process after a promise is resolved. We're allowed and expected to access reactive values and expressions from these handlers.
+Nope—this code is just fine. The prohibition is against reading reactive values/expressions from *inside* a mirai, because code inside a mirai is executed in a totally different R process. The steps in a promise-pipeline are not mirai, but promise handlers. These aren't executed in a different process; rather, they're executed back in the original R process after a promise is resolved. We're allowed and expected to access reactive values and expressions from these handlers.
 
 ### The `whale_downloads` reactive: reading from multiple promises
 
@@ -329,7 +329,7 @@ This solution uses the [promise gathering](https://rstudio.github.io/promises/ar
 * The `promise_all` function gathers multiple promise objects together, and returns a single promise object. This new promise object doesn't resolve until all the input promise objects are resolved, and it yields a list of those results.
 
 ```r
-> promise_all(a = future_promise("Hello"), b = future_promise("World")) %...>% print()
+> promise_all(a = mirai("Hello"), b = mirai("World")) %...>% print()
 $a
 [1] "Hello"
 
@@ -353,13 +353,13 @@ Error: object 'x' not found
 Let's once again combine the three, with the simplest possible example of the gathering pattern:
 
 ```r
-> promise_all(x = future_promise("Hello"), y = future_promise("World")) %...>%
+> promise_all(x = mirai("Hello"), y = mirai("World")) %...>%
 +   with({ paste(x, y) }) %...>%
 +   print()
 [1] "Hello World"
 ```
 
-You can make use of this pattern without remembering exactly how these pieces combine. Just remember that the arguments to `promise_all` provide the promise objects (`future_promise(1)` and `future_promise(2)`), along with the names you want to use to refer to their yielded values (`x ` and `y`); and the code block you put in `with()` can refer to those names without worrying about the fact that they were ever promises to begin with.
+You can make use of this pattern without remembering exactly how these pieces combine. Just remember that the arguments to `promise_all` provide the promise objects (`mirai(1)` and `mirai(2)`), along with the names you want to use to refer to their yielded values (`x ` and `y`); and the code block you put in `with()` can refer to those names without worrying about the fact that they were ever promises to begin with.
 
 ### The `total_downloaders` value box: simple pipelines are for output, too
 
@@ -501,15 +501,15 @@ data <- eventReactive(input$date, {
 })
 ```
 
-Progress reporting currently presents two challenges for future.
+Progress reporting currently presents two challenges for mirai.
 
-First, the `withProgress({...})` function cannot be used with async. `withProgress` is designed to wrap a slow synchronous action, and dismisses its progress dialog when the block of code it wraps is done executing. Since the call to `future_promise()` will return immediately even though the actual task is far from done, using `withProgress` won't work; the progress dialog would be dismissed before the download even got going.
+First, the `withProgress({...})` function cannot be used with async. `withProgress` is designed to wrap a slow synchronous action, and dismisses its progress dialog when the block of code it wraps is done executing. Since the call to `mirai()` will return immediately even though the actual task is far from done, using `withProgress` won't work; the progress dialog would be dismissed before the download even got going.
 
-It's conceivable that `withProgress` could gain promise compatibility someday, but it's not in Shiny v1.1.0. In the meantime, we can work around this by using the alternative, [object-oriented progress API](https://shiny.posit.co/r/reference/shiny/latest/progress.html) that Shiny offers. It's a bit more verbose and fiddly than `withProgress`/`setProgress`, but it is flexible enough to work with futures/promises.
+It's conceivable that `withProgress` could gain promise compatibility someday, but it's not in Shiny v1.1.0. In the meantime, we can work around this by using the alternative, [object-oriented progress API](https://shiny.posit.co/r/reference/shiny/latest/progress.html) that Shiny offers. It's a bit more verbose and fiddly than `withProgress`/`setProgress`, but it is flexible enough to work with mirai/promises.
 
-Second, progress messages can't be sent from futures. This is simply because futures are executed in child processes, which don't have direct access to the browser like the main Shiny process does.
+Second, progress messages can't be sent from mirai. This is simply because mirai are executed in child processes, which don't have direct access to the browser like the main Shiny process does.
 
-It's conceivable that `future` could gain the ability for child processes to communicate back to their parents, but no good solution exists at the time of this writing. In the meantime, we can work around this by taking the one future that does both downloading and parsing, and splitting it into two separate futures. After the download future has completed, we can send a progress message that parsing is beginning, and then start the parsing future.
+It's conceivable that `mirai` could gain the ability for child processes to communicate back to their parents, but no good solution exists at the time of this writing. In the meantime, we can work around this by taking the one mirai that does both downloading and parsing, and splitting it into two separate mirai. After the download mirai has completed, we can send a progress message that parsing is beginning, and then start the parsing mirai.
 
 The regrettably complicated solution is below.
 
@@ -525,25 +525,28 @@ data <- eventReactive(input$date, {
 
   p <- Progress$new()
   p$set(value = NULL, message = "Downloading data...")
-  future_promise({
+  mirai({
     if (!file.exists(path)) {
       download.file(url, path)
-    }
+    },
+    path = path, url = url
   }) %...>%
     { p$set(message = "Parsing data...") } %...>%
-    { future_promise(read_csv(path, col_types = "Dti---c-ci", progress = FALSE)) } %>%
+    { mirai({
+        read_csv(path, col_types = "Dti---c-ci", progress = FALSE)
+      }, path = path) } %>%
     finally(~p$close())
 })
 ```
 
-The single future we wrote earlier has now become a pipeline of promises:
+The single mirai we wrote earlier has now become a pipeline of promises:
 
-1. future (download)
+1. mirai (download)
 2. send progress message
-3. future (parse)
+3. mirai (parse)
 4. dismiss progress dialog
 
-Note that neither the R6 call `p$set(message = ...)` nor the second `future_promise()` call are tidy, so they use curly-brace blocks, as discussed in the above section about `biggest_whales`.
+Note that neither the R6 call `p$set(message = ...)` nor the second `mirai()` call are tidy, so they use curly-brace blocks, as discussed in the above section about `biggest_whales`.
 
 The final step of dismissing the progress dialog doesn't use `%...>%` at all; because we want the progress dialog to dismiss whether the download and parse operations succeed or fail, we use the regular pipe `%>%` and `finally()` function instead. See the relevant section in [*Working with promises in R*](https://rstudio.github.io/promises/articles/overview.html#cleaning-up-with-finally) to learn more.
 
@@ -577,9 +580,9 @@ And as you can see from this plot, the behavior of the async app is much improve
 
 I was surprised that the async version's page load times weren't even faster, and even more surprised to see that the blue rectangles were just as wide as the sync version. Why isn't the async version way faster? The sync version does all of its work on a single thread, and I specifically designed this app to be a nightmare for scalability by having each session kick off by parsing hundreds of megabytes of CSV, an operation that is quite expensive. The async version gets to spread these jobs across several workers. Why aren't we seeing a greater time savings?
 
-Mostly, it's because calling `future_promise(read_csv("big_file.csv"))` is almost a worst-case scenario for future and async. `read_csv` is generally fast, but because the CRAN log files are so big, `read_csv("big_file.csv")` is slow. The value it returns is a very large data frame, that has now been loaded not into the Shiny process, but a `future` worker process. In order to return that data frame to the Shiny process, that data must first be serialized (I believe `future` essentially uses `saveRDS` for this), transmitted to the Shiny process, and then deserialized; to make matters worse, the transmitting and deserialization steps happen on the main R thread that we're working so hard to try to keep idle. **The larger the data we send back and forth to the future, the more performance suffers,** and in this case we're sending back quite a lot of data.
+Mostly, it's because calling `mirai(read_csv("big_file.csv"))` is almost a worst-case scenario for mirai and async. `read_csv` is generally fast, but because the CRAN log files are so big, `read_csv("big_file.csv")` is slow. The value it returns is a very large data frame, that has now been loaded not into the Shiny process, but a `mirai` daemon process. In order to return that data frame to the Shiny process, that data must first be serialized, transmitted to the Shiny process, and then deserialized; to make matters worse, the transmitting and deserialization steps happen on the main R thread that we're working so hard to try to keep idle. **The larger the data we send back and forth to the mirai, the more performance suffers,** and in this case we're sending back quite a lot of data.
 
-We can make our code significantly faster by doing more summarizing, aggregation, and filtering _inside_ the future; not only does this make more of the work happen in parallel, but by returning the data in already-processed form, we can have much less data to transfer from the worker process back to the Shiny process. (For example, the data for May 31, 2018 weighs 75MB before optimization, and 8.8MB afterwards.)
+We can make our code significantly faster by doing more summarizing, aggregation, and filtering _inside_ the mirai; not only does this make more of the work happen in parallel, but by returning the data in already-processed form, we can have much less data to transfer from the worker process back to the Shiny process. (For example, the data for May 31, 2018 weighs 75MB before optimization, and 8.8MB afterwards.)
 
 Compare all three runs in the image below (the newly optimized version is labelled "async2"). The homepage load times have dropped further, and the calculation times are now dramatically faster than the sync code.
 
@@ -597,7 +600,7 @@ To get a visceral sense for what it feels like to use the app under load, here's
 <iframe class="embed-responsive-item" src="https://www.youtube-nocookie.com/embed/HsjdEZMnb0w?rel=0&amp;showinfo=0&amp;ecver=1" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </p>
 
-Take a look at the [code diff for async vs. async2](https://github.com/rstudio/cranwhales/compare/async...async2?diff=split). While the code has not changed very dramatically, it has lost a little elegance and maintainability: the code for each of the affected outputs now has one foot in the the render function and one foot in the future. If your app's total audience is a team of a hundred analysts and execs, you may choose to forgo the extra performance and stick with the original async (or even sync) code. But if you have serious scaling needs, the refactoring is probably a small price to pay.
+Take a look at the [code diff for async vs. async2](https://github.com/rstudio/cranwhales/compare/async...async2?diff=split). While the code has not changed very dramatically, it has lost a little elegance and maintainability: the code for each of the affected outputs now has one foot in the the render function and one foot in the mirai. If your app's total audience is a team of a hundred analysts and execs, you may choose to forgo the extra performance and stick with the original async (or even sync) code. But if you have serious scaling needs, the refactoring is probably a small price to pay.
 
 Let's get real for a second, though. If this weren't an example app written for exposition purposes, but a real production app that was intended to scale to thousands of concurrent users across dozens of R processes, we wouldn't download and parse CSV files on the fly. Instead, we'd establish a proper [ETL procedure](https://solutions.posit.co/gallery/twitter-etl/) to run every night and put the results into a properly indexed database table, or RDS files with just the data we need. As I said [earlier](#improving-performance-and-scalability), a little precomputation and caching can make a huge difference!
 


### PR DESCRIPTION
Closes #131.

This substantially overhauls the vignettes to describe promises usage with mirai.

- Updates examples in all vignettes to use mirai
- Adds new launching tasks with mirai vignette
- Keeps future / future_promise vignettes untouched (apart from a mirai / future considerations box)

Note that there's a little gymnastics with the file names to preserve ordering (as there's a reference to the `promises_04_futures.html` vignette in the Shiny docs). I don't think this matters as they're not really visible, but if there's a better way to do this do let me know!