### PR TITLE
Provides intro for vignette updates

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -4,6 +4,7 @@ CMD
 Cheng's
 ETL
 FutureErrors
+futureverse
 Globals
 Hadley’s
 JS

--- a/vignettes/promises_04_mirai.Rmd
+++ b/vignettes/promises_04_mirai.Rmd
@@ -18,6 +18,16 @@ vignette: >
 }
 ```
 
+We've updated this guide to using the `mirai` package from `future` as we believe the following benefits are compelling in the context of Shiny apps:
+
+1. Faster startup times and much less per-task overhead, meaning you can boost performance by making even shorter tasks async.
+1. More linear scaling, meaning you get the same relative benefits whether running 2 or 200 cores.
+1. Event-driven promises using `mirai` vs. promises using `future` which time-poll every 100 ms. Lower latency and response times can help with the user experience.
+
+The previous guide using `future` is available [here](promises_05a_futures.html). Using `future` continues to be supported within the Shiny ecosystem, and Henrik Bengtsson‘s excellent work on the futureverse deserves credit for pushing the boundaries of parallelism in R farther than many thought possible.
+
+<hr>
+
 The `mirai` package provides a lightweight way to launch R tasks that don't block the current R session.
 
 The `promises` package provides the API for working with the results of async tasks, but it totally abdicates responsibility for actually launching/creating async tasks. The idea is that any number of different packages could be capable of launching async tasks, using whatever techniques they want, but all of them would either return promise objects or objects that can be converted to promise objects, as is the case for `mirai`.

--- a/vignettes/promises_05a_futures.Rmd
+++ b/vignettes/promises_05a_futures.Rmd
@@ -18,16 +18,6 @@ vignette: >
 }
 ```
 
-<div class="alert alert-secondary">
-While this article focuses on the `future` package, you may wish to consider the newer [`mirai`](promises_04_mirai.html) package, which didn't exist when this article was first written.
-Here are some factors to consider as you choose between the two.
-
-1. The `future` package tries hard to automatically infer what variables and packages you need from the main R session, and makes those available to the child process. `mirai` doesn't try to do this for you; you need to pass in whatever data you need explicitly, and namespace package function calls within your code.
-2. `mirai` is very fast; it's much faster than `future` at starting up and has less per-task overhead. `mirai` creates event-driven promises, whereas promises using `future` time-poll every 0.1 seconds. This makes `mirai` much better-suited to situations where response times and latency are critical.
-3. `future` is designed to be a general API, and supports distributed computing backends provided by other packages. `mirai` on the other hand provides integrated launchers for high-performance computing clusters and any computer reachable via SSH.
-4. `mirai` is designed as an async framework and is inherently queued, meaning it readily accepts more tasks than workers. This means the distinction between `future()` and `future_promise()` doesn't exist for mirai.
-</div>
-
 The `future` package provides a lightweight way to launch R tasks that don't block the current R session. It was created by Henrik Bengtsson long before the `promises` package existed—the first CRAN release of `future` predates development of `promises` by almost two years!
 
 The `promises` package provides the API for working with the results of async tasks, but it totally abdicates responsibility for actually launching/creating async tasks. The idea is that any number of different packages could be capable of launching async tasks, using whatever techniques they want, but all of them would either return promise objects or objects that can be converted to promise objects, as is the case for `future`.


### PR DESCRIPTION
Adds:
- Rationale for move to mirai.
- Note that use of future continues to be supported within the Shiny ecosystem.

Follow up to #136 and #140.