### PR TITLE
Ensure execution order of promise chains

### DIFF
--- a/R/promise.R
+++ b/R/promise.R
@@ -66,10 +66,12 @@ Promise <- R6::R6Class(
       private$visible <- visible
       private$state <- "fulfilled"
 
-      lapply(private$onFulfilled, function(f) {
-        f(private$value, private$visible)
+      later::later(function() {
+        lapply(private$onFulfilled, function(f) {
+          f(private$value, private$visible)
+        })
+        private$onFulfilled <- list()
       })
-      private$onFulfilled <- list()
     },
     doRejectFinalReason = function(reason) {
       private$value <- reason

--- a/R/promise.R
+++ b/R/promise.R
@@ -66,12 +66,10 @@ Promise <- R6::R6Class(
       private$visible <- visible
       private$state <- "fulfilled"
 
-      later::later(function() {
-        lapply(private$onFulfilled, function(f) {
-          f(private$value, private$visible)
-        })
-        private$onFulfilled <- list()
+      lapply(private$onFulfilled, function(f) {
+        f(private$value, private$visible)
       })
+      private$onFulfilled <- list()
     },
     doRejectFinalReason = function(reason) {
       private$value <- reason

--- a/tests/testthat/test-ordering.R
+++ b/tests/testthat/test-ordering.R
@@ -1,0 +1,11 @@
+test_that("promise resolution order matches expectations", {
+  # See discussion in #151 - this is just the current behaviour. There may be
+  # grounds for change if we find a legitimate reason for doing so.
+  y <- 0L
+  p1 <- promise_resolve(1) |> then(\(x) y <<- y + 1) |> then(\(x) y <<- y / 2)
+  p2 <- promise_resolve(2) |> then(\(x) y <<- y + 3) |> then(\(x) y <<- y * 2)
+  later::run_now()
+  expect_equal(y, 4)
+  later::run_now()
+  expect_equal(y, 4)
+})


### PR DESCRIPTION
Closes #150.

The final resolution is taken out of the `later::later()` call in this PR. The tests below behave identically before and after this PR.

Revdepcheck cloud check was also run and returned clean.

```r
library(promises)

then(mirai::mirai(1), function(x) stop("outer"))
then(mirai::mirai(stop("inner")), function(x) stop("outer"))
then(mirai::mirai(non), function(x) stop("outer"))
then(mirai::mirai(stop("inner")), function(x) stop("outer"), function(x) stop("rejected"))
then(mirai::mirai(rexp()), function(x) stop("outer"), function(x) print(x))
then(mirai::mirai(TRUE), print)
mirai::mirai(1) |> then(\(x) stop("outer1")) |> then(\(x) stop("resolved"), \(x) stop("rejected"))
mirai::mirai(1) |> then(\(x) stop("outer1")) |> then(\(x) stop("resolved"), \(x) print(x))
mirai::mirai(stop("inner")) |> then(\(x) stop("resolved"), \(x) "rejected") |> then(\(x) stop("really rejected"))
mirai::mirai(stop("inner")) |> then(\(x) stop("resolved"), \(x) "rejected") |> then(\(x) print(paste0("not really ", x)))

then(future_promise(1), function(x) stop("outer"))
then(future_promise(stop("inner")), function(x) stop("outer"))
then(future_promise(non), function(x) stop("outer"))
then(future_promise(stop("inner")), function(x) stop("outer"), function(x) stop("rejected"))
then(future_promise(rexp()), function(x) stop("outer"), function(x) print(x))
then(future_promise(TRUE), print)
future_promise(1) |> then(\(x) stop("outer1")) |> then(\(x) stop("resolved"), \(x) stop("rejected"))
future_promise(1) |> then(\(x) stop("outer1")) |> then(\(x) stop("resolved"), \(x) print(x))
future_promise(stop("inner")) |> then(\(x) stop("resolved"), \(x) "rejected") |> then(\(x) stop("really rejected"))
future_promise(stop("inner")) |> then(\(x) stop("resolved"), \(x) "rejected") |> then(\(x) print(paste0("not really ", x)))
```

Importantly, this doesn't affect the expected ordering of callbacks. In the following case 'first' will be printed before 'second':

```r
p <- promise_resolve(NULL)
p$then(function(x) cat("second\n"))
cat("first\n")
```