### PR TITLE
Avoid formula notation in package code for performance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,10 +4,14 @@ Title: Abstractions for Promise-Based Asynchronous Programming
 Version: 1.3.3.9000
 Authors@R: c(
     person("Joe", "Cheng", , "joe@posit.co", role = c("aut", "cre")),
-    person("Barret", "Schloerke", , "barret@posit.co", role = "aut", comment = c(ORCID = "0000-0001-9986-114X")),
-    person("Winston", "Chang", , "winston@posit.co", role = "aut", comment = c(ORCID = "0000-0002-1576-2126")),
-    person("Charlie", "Gao", , "charlie.gao@posit.co", role = "aut", comment = c(ORCID = "0000-0002-0750-061X")),
-    person("Posit Software, PBC", role = c("cph", "fnd"), comment = c(ROR = "03wc8by49"))
+    person("Barret", "Schloerke", , "barret@posit.co", role = "aut",
+           comment = c(ORCID = "0000-0001-9986-114X")),
+    person("Winston", "Chang", , "winston@posit.co", role = "aut",
+           comment = c(ORCID = "0000-0002-1576-2126")),
+    person("Charlie", "Gao", , "charlie.gao@posit.co", role = "aut",
+           comment = c(ORCID = "0000-0002-0750-061X")),
+    person("Posit Software, PBC", role = c("cph", "fnd"),
+           comment = c(ROR = "03wc8by49"))
   )
 Description: Provides fundamental abstractions for doing asynchronous
     programming in R using promises. Asynchronous programming is useful

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Authors@R: c(
     person("Joe", "Cheng", , "joe@posit.co", role = c("aut", "cre")),
     person("Barret", "Schloerke", , "barret@posit.co", role = "aut", comment = c(ORCID = "0000-0001-9986-114X")),
     person("Winston", "Chang", , "winston@posit.co", role = "aut", comment = c(ORCID = "0000-0002-1576-2126")),
+    person("Charlie", "Gao", , "charlie.gao@posit.co", role = "aut", comment = c(ORCID = "0000-0002-0750-061X")),
     person("Posit Software, PBC", role = c("cph", "fnd"), comment = c(ROR = "03wc8by49"))
   )
 Description: Provides fundamental abstractions for doing asynchronous

--- a/R/promise.R
+++ b/R/promise.R
@@ -87,7 +87,7 @@ Promise <- R6::R6Class(
         private$onRejected <- list()
 
         later::later(
-          ~ {
+          function() {
             if (!private$rejectionHandled) {
               # warning() was unreliable here
               cat(
@@ -405,13 +405,13 @@ promise <- function(action) {
 #'
 #' @export
 promise_resolve <- function(value) {
-  promise(~ resolve(value))
+  promise(function(resolve, reject) resolve(value))
 }
 
 #' @rdname promise_resolve
 #' @export
 promise_reject <- function(reason) {
-  promise(~ reject(reason))
+  promise(function(resolve, reject) reject(reason))
 }
 
 #' Coerce to a promise

--- a/R/utils.R
+++ b/R/utils.R
@@ -45,7 +45,7 @@ promise_all <- function(..., .list = NULL) {
   }
 
   if (length(.list) == 0) {
-    return(promise(~ resolve(list())))
+    return(promise(function(resolve, reject) resolve(list())))
   }
 
   # Verify that .list members are either all named or all unnamed

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -13,6 +13,7 @@ mirai
 Multisession
 NSE
 OpenCPU
+ORCID
 PBC
 RServe
 RStudio

--- a/man/promises-package.Rd
+++ b/man/promises-package.Rd
@@ -24,6 +24,7 @@ Authors:
 \itemize{
   \item Barret Schloerke \email{barret@posit.co} (\href{https://orcid.org/0000-0001-9986-114X}{ORCID})
   \item Winston Chang \email{winston@posit.co} (\href{https://orcid.org/0000-0002-1576-2126}{ORCID})
+  \item Charlie Gao \email{charlie.gao@posit.co} (\href{https://orcid.org/0000-0002-0750-061X}{ORCID})
 }
 
 Other contributors:


### PR DESCRIPTION
Closes #152.

This will lead to a speed up for all helper functions: `promise_all()`, `promise_race()`, `promise_map()` and `promise_reduce()`.

The elimination of the formula notation for the `later::later()` call for promise rejections avoids implicitly calling `rlang::as_function()` in that case, which is relatively expensive.