### PR TITLE
Implement `check_dots()` after `rlang::check_dots_empty0()`

### DIFF
--- a/R/then.R
+++ b/R/then.R
@@ -130,7 +130,7 @@ then <- function(
   ...,
   tee = FALSE
 ) {
-  rlang::check_dots_empty()
+  check_dots(...)
   check_tee(tee)
 
   promise <- as.promise(promise)
@@ -178,7 +178,7 @@ then <- function(
 #' @rdname then
 #' @export
 catch <- function(promise, onRejected, ..., tee = FALSE) {
-  rlang::check_dots_empty()
+  check_dots(...)
   promise <- as.promise(promise)
   check_tee(tee)
 
@@ -211,6 +211,11 @@ finally <- function(promise, onFinally) {
   promise$finally(onFinally)
 }
 
+check_dots <- function(..., call = parent.frame()) {
+  if (nargs()) {
+    rlang::check_dots_empty(call = call)
+  }
+}
 
 check_tee <- function(tee) {
   if (is.logical(tee)) {


### PR DESCRIPTION
A follow up to #157.

I came across `rlang::check_dots_empty0()` in another codebase and looking at the [definition](https://github.com/r-lib/rlang/blob/7371bac25ffe9b91097e0dad424cec5b2ee3c288/R/dots-ellipsis.R#L221-L225) realised it's exactly what we need here to avoid the performance impact.

I've defined our own function here so rlang only needs to be loaded along the error paths.