### PR TITLE
perf: Use counter instead of array check in `promise_all()`; Preserve values for duplicate named arguments to `promise_all()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Fixed #47: `promise_map()` can now properly handle `NULL` values being returned. (Thank you, @RLesur! #138)
 
+* Improved performance of `promise_all()` by using a counter instead of checking completion status of all promises. This changes the time complexity from `O(n^2)` to `O(n)` for determining when all promises are complete. (#163)
+
 # promises 1.3.3
 
 * Changed the way we create future objects to stay compatible with new versions of `{future}`. Apparently the way we were doing it was never idiomatic and only worked by accident. (#121)

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * Improved performance of `promise_all()` by using a counter instead of checking completion status of all promises. This changes the time complexity from `O(n^2)` to `O(n)` for determining when all promises are complete. (#163)
 
+* Fixed a bug in `promise_all()` where duplicate named arguments (or `.list` entries) were not preserved. Now, a result will be produced for every promise provided. (#163)
+
 # promises 1.3.3
 
 * Changed the way we create future objects to stay compatible with new versions of `{future}`. Apparently the way we were doing it was never idiomatic and only worked by accident. (#121)

--- a/R/utils.R
+++ b/R/utils.R
@@ -63,25 +63,24 @@ promise_all <- function(..., .list = NULL) {
 
   promise(function(resolve, reject) {
     remaining <- length(.list)
-    if (is.null(listnames)) {
-      keys <- seq_len(remaining)
-    } else {
-      keys <- listnames
-      names(keys) <- listnames
+    indices <- seq_len(remaining)
+    if (nameCount > 0) {
+      # By setting names, `results` will have the same names
+      names(indices) <- listnames
     }
 
-    results <- lapply(keys, function(key) {
-      # done[[key]] <<- FALSE
+    results <- lapply(indices, function(idx) {
+      # done[[idx]] <<- FALSE
       then(
-        .list[[key]],
+        .list[[idx]],
         onFulfilled = function(value) {
           # Save the result so we can return it to the user.
-          # This weird assignment is similar to `results[[key]] <- value`, except
+          # This weird assignment is similar to `results[[idx]] <- value`, except
           # that it handles NULL values correctly.
-          results[key] <<- list(value)
+          results[idx] <<- list(value)
 
           # Record the fact that the promise was completed.
-          # done[[key]] <<- TRUE
+          # done[[idx]] <<- TRUE
           remaining <<- remaining - 1L
 
           # If all of the tasks are done, resolve.
@@ -95,8 +94,13 @@ promise_all <- function(..., .list = NULL) {
           reject(reason)
         }
       )
+
+      # Init each `results` entry as `NA` until `onFulfilled()` is called
       NA
     })
+
+    # Return nothing to promise
+    NULL
   })
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -58,7 +58,7 @@ promise_all <- function(..., .list = NULL) {
     )
   }
 
-  done <- list()
+  # done <- list()
   results <- list()
 
   promise(function(resolve, reject) {
@@ -68,8 +68,12 @@ promise_all <- function(..., .list = NULL) {
       names(.list)
     }
 
+    doneCounter <- 0
+    n <- length(.list)
+
     lapply(keys, function(key) {
-      done[[key]] <<- FALSE
+      # done[[key]] <<- FALSE
+
       # Forces correct/deterministic ordering of the result list's elements
       results[[key]] <<- NA
 
@@ -82,14 +86,19 @@ promise_all <- function(..., .list = NULL) {
           results[key] <<- list(value)
 
           # Record the fact that the promise was completed.
-          done[[key]] <<- TRUE
+          # done[[key]] <<- TRUE
+          doneCounter <<- doneCounter + 1
+
           # If all of the tasks are done, resolve.
-          if (all(as.logical(done))) {
+          if (
+            doneCounter == n
+            #  && all(as.logical(done))
+          ) {
             resolve(results)
           }
         },
         onRejected = function(reason) {
-          # TODO: Cancel promises that are still running
+          # TODO: Cancel promises that are still running; Use `done` list
           reject(reason)
         }
       )

--- a/tests/testthat/test-combining.R
+++ b/tests/testthat/test-combining.R
@@ -25,4 +25,13 @@ describe("promise_all", {
     )
     expect_identical(extract(x), list(a = NULL, b = NULL, c = NULL))
   })
+
+  it("handles duplicate names correctly", {
+    x <- resolve_later(1, 0.5)
+    y <- resolve_later(2, 0.3)
+    z <- resolve_later(3, 0.1)
+
+    x <- promise_all(.list = list(a = x, a = y, a = z))
+    expect_identical(extract(x), list(a = 1, a = 2, a = 3))
+  })
 })


### PR DESCRIPTION
Fixes #162 

Note: Keeping `done` code commented as it will be needed if we want to eventually cancel promises