### PR TITLE
chore: Add r-lib/otelsdk to check dependencies. Require otel >= 0.2.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,6 +25,8 @@ jobs:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
     with:
       cache-version: "regular"
+      extra-packages: |
+        r-lib/otelsdk
 
   R-CMD-check-with-dont-test:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,6 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/Needs/website: rsconnect, tidyverse/tidytemplate
-Config/Needs/check: r-lib/otelsdk
 Config/testthat/edition: 3
 Config/usethis/last-upkeep: 2025-05-27
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     future (>= 1.21.0),
     knitr,
     mirai,
-    otel,
+    otel (>= 0.2.0),
     purrr,
     Rcpp,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/Needs/website: rsconnect, tidyverse/tidytemplate
+Config/Needs/check: r-lib/otelsdk
 Config/testthat/edition: 3
 Config/usethis/last-upkeep: 2025-05-27
 Encoding: UTF-8

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 skip_if_not_installed("otel")
 skip_if_not_installed("otelsdk")
 


### PR DESCRIPTION
Included 'r-lib/otelsdk' under Config/Needs/check in the DESCRIPTION file to specify it as a required package for checks.