### PR TITLE
refactor(otel): Ensure production safety by using otel functions over methods directly

### DIFF
--- a/R/otel.R
+++ b/R/otel.R
@@ -178,9 +178,8 @@ otel_tracer_name <- "co.posit.r-package.promises"
 #' @section OpenTelemetry span compatibility:
 #'
 #' For ospan objects to exist over may async ticks, the ospan must be created
-#' using `otel::start_span()` and later ended using `spn$end()` (or
-#' `otel::end_span()`). Ending the ospan must occur **after** any promise chain
-#' work has completed.
+#' using `otel::start_span()` and later ended using `otel::end_span()`. Ending
+#' the ospan must occur **after** any promise chain work has completed.
 #'
 #' If we were to instead use `otel::start_local_active_span()`, the ospan would
 #' be ended when the function exits, not when the promise chain completes. Even
@@ -308,7 +307,7 @@ with_ospan_async <- function(
 
   needs_cleanup <- TRUE
   cleanup <- function() {
-    span$end()
+    otel::end_span(span)
   }
   on.exit(if (needs_cleanup) cleanup(), add = TRUE)
 

--- a/man/otel.Rd
+++ b/man/otel.Rd
@@ -284,9 +284,8 @@ ospan is reactivated via \code{with_active_span()}. (Performed by the initial
 
 
 For ospan objects to exist over may async ticks, the ospan must be created
-using \code{otel::start_span()} and later ended using \code{spn$end()} (or
-\code{otel::end_span()}). Ending the ospan must occur \strong{after} any promise chain
-work has completed.
+using \code{otel::start_span()} and later ended using \code{otel::end_span()}. Ending
+the ospan must occur \strong{after} any promise chain work has completed.
 
 If we were to instead use \code{otel::start_local_active_span()}, the ospan would
 be ended when the function exits, not when the promise chain completes. Even

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -13,6 +13,7 @@ with_ospan_promise_domain({
         })
         expect_true(!is.null(records$traces[["test_span0"]]))
 
+        skip_if(!Sys.getenv("OTEL_TRACES_EXPORTER") %in% c("", "none"))
         expect_s3_class(
           otel::start_span("test_span"),
           "otel_span_noop"

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -9,7 +9,7 @@ with_ospan_promise_domain({
         records <- otelsdk::with_otel_record({
           span <- otel::start_span("test_span0", tracer = NULL)
           expect_true(inherits(span, "otel_span"))
-          span$end()
+          otel::end_span(span)
         })
         expect_true(!is.null(records$traces[["test_span0"]]))
 
@@ -154,25 +154,25 @@ with_ospan_promise_domain({
           promise_resolve("init1") |>
             then(function(x) {
               spn <- otel::start_span("chain1_step1")
-              on.exit(spn$end())
+              on.exit(otel::end_span(spn))
               execution_order <<- c(execution_order, "chain1_step1")
               paste0(x, "_step11")
             }) |>
             then(function(x) {
               spn <- otel::start_span("chain1_step2")
-              on.exit(spn$end())
+              on.exit(otel::end_span(spn))
               execution_order <<- c(execution_order, "chain1_step2")
               paste0(x, "_step12")
             }) |>
             then(function(x) {
               spn <- otel::start_span("chain1_step3")
-              on.exit(spn$end())
+              on.exit(otel::end_span(spn))
               execution_order <<- c(execution_order, "chain1_step3")
               paste0(x, "_step13")
             }) |>
             then(function(x) {
               spn <- otel::start_span("chain1_step4")
-              on.exit(spn$end())
+              on.exit(otel::end_span(spn))
               execution_order <<- c(execution_order, "chain1_step4")
               paste0(x, "_final1")
             })
@@ -182,25 +182,25 @@ with_ospan_promise_domain({
           promise_resolve("init2") |>
             then(function(x) {
               spn <- otel::start_span("chain2_step1")
-              on.exit(spn$end())
+              on.exit(otel::end_span(spn))
               execution_order <<- c(execution_order, "chain2_step1")
               paste0(x, "_step12")
             }) |>
             then(function(x) {
               spn <- otel::start_span("chain2_step2")
-              on.exit(spn$end())
+              on.exit(otel::end_span(spn))
               execution_order <<- c(execution_order, "chain2_step2")
               paste0(x, "_step22")
             }) |>
             then(function(x) {
               spn <- otel::start_span("chain2_step3")
-              on.exit(spn$end())
+              on.exit(otel::end_span(spn))
               execution_order <<- c(execution_order, "chain2_step3")
               paste0(x, "_step23")
             }) |>
             then(function(x) {
               spn <- otel::start_span("chain2_step4")
-              on.exit(spn$end())
+              on.exit(otel::end_span(spn))
               execution_order <<- c(execution_order, "chain2_step4")
               paste0(x, "_final2")
             })
@@ -337,7 +337,7 @@ describe("local_ospan_promise_domain()", {
           then(function(x) {
             # This should be executed within the ospan domain
             span <- otel::start_span("inner_test_span")
-            on.exit(span$end())
+            on.exit(otel::end_span(span))
             x * 2
           })
       })


### PR DESCRIPTION
- Replaces all `spn$end()` with `otel::end_span(spn)`.