### PR TITLE
Do not import base packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,8 +32,7 @@ Imports:
     magrittr (>= 1.5),
     otel (>= 0.2.0),
     R6,
-    rlang,
-    stats
+    rlang
 Suggests:
     future (>= 1.21.0),
     knitr,


### PR DESCRIPTION
I've always adhered to this, and notice that this is now becoming Tidyverse practice.