### PR TITLE
✨ Migrate to cpp11 ✨

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,9 +25,15 @@ jobs:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
     with:
       cache-version: "regular-1"
+      extra-packages: |
+        any::decor
+        any::tibble
 
   R-CMD-check-with-dont-test:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
     with:
       extra-check-args: '"--run-donttest"'
       cache-version: "donttest-1"
+      extra-packages: |
+        any::decor
+        any::tibble

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,15 +25,9 @@ jobs:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
     with:
       cache-version: "regular-1"
-      extra-packages: |
-        any::decor
-        any::tibble
 
   R-CMD-check-with-dont-test:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
     with:
       extra-check-args: '"--run-donttest"'
       cache-version: "donttest-1"
-      extra-packages: |
-        any::decor
-        any::tibble

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,3 +31,23 @@ jobs:
     with:
       extra-check-args: '"--run-donttest"'
       cache-version: "donttest-1"
+
+  cpp-extra-test:
+    name: cpp-extra-test
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout GitHub repo
+        uses: rstudio/shiny-workflows/.github/internal/checkout@v1
+
+      - name: Install R, system dependencies, and package dependencies
+        uses: rstudio/shiny-workflows/setup-r-package@v1
+        with:
+          needs: check
+          extra-packages: any::pkgload
+      - name: Run testthat on test-cpp.R
+        run: |
+          pkgload::load_all()
+          testthat::test_file(file.path("tests", "testthat", "test-cpp.R"))
+        shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Suggests:
     vembedr
 VignetteBuilder:
     knitr
+Config/Needs/check: decor, tibble
 Config/Needs/website: rsconnect, tidyverse/tidytemplate
 Config/testthat/edition: 3
 Config/usethis/last-upkeep: 2025-05-27

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,12 +34,12 @@ Imports:
     R6,
     rlang
 Suggests:
+    cpp11,
     future (>= 1.21.0),
     knitr,
     mirai,
     otelsdk (>= 0.2.0),
     purrr,
-    Rcpp,
     rmarkdown,
     spelling,
     testthat (>= 3.0.0),

--- a/tests/testthat/test-cpp.R
+++ b/tests/testthat/test-cpp.R
@@ -1,9 +1,9 @@
-print(library())
-
 describe("C++ interface", {
+  skip_on_cran()
   # `cpp11::cpp_source()` errors if these packages are not installed:
   # brio, callr, cli, decor, desc, glue, tibble, vctrs
-  skip_on_cran()
+  skip_if_not_installed("decor")
+  skip_if_not_installed("tibble")
 
   env <- new.env()
   cpp11::cpp_source(

--- a/tests/testthat/test-cpp.R
+++ b/tests/testthat/test-cpp.R
@@ -1,13 +1,7 @@
 describe("C++ interface", {
   # `cpp11::cpp_source()` errors if these packages are not installed:
-  skip_if_not_installed("brio")
-  skip_if_not_installed("callr")
-  skip_if_not_installed("cli")
-  skip_if_not_installed("decor")
-  skip_if_not_installed("desc")
-  skip_if_not_installed("glue")
-  skip_if_not_installed("tibble")
-  skip_if_not_installed("vctrs")
+  # brio, callr, cli, decor, desc, glue, tibble, vctrs
+  skip_on_cran()
 
   env <- new.env()
   cpp11::cpp_source(

--- a/tests/testthat/test-cpp.R
+++ b/tests/testthat/test-cpp.R
@@ -1,6 +1,6 @@
 describe("C++ interface", {
   env <- new.env()
-  Rcpp::sourceCpp(
+  cpp11::cpp_source(
     system.file("promise_task.cpp", package = "promises"),
     env = env
   )

--- a/tests/testthat/test-cpp.R
+++ b/tests/testthat/test-cpp.R
@@ -1,4 +1,14 @@
 describe("C++ interface", {
+  # `cpp11::cpp_source()` errors if these packages are not installed:
+  skip_if_not_installed("brio")
+  skip_if_not_installed("callr")
+  skip_if_not_installed("cli")
+  skip_if_not_installed("decor")
+  skip_if_not_installed("desc")
+  skip_if_not_installed("glue")
+  skip_if_not_installed("tibble")
+  skip_if_not_installed("vctrs")
+
   env <- new.env()
   cpp11::cpp_source(
     system.file("promise_task.cpp", package = "promises"),

--- a/tests/testthat/test-cpp.R
+++ b/tests/testthat/test-cpp.R
@@ -1,3 +1,5 @@
+print(library())
+
 describe("C++ interface", {
   # `cpp11::cpp_source()` errors if these packages are not installed:
   # brio, callr, cli, decor, desc, glue, tibble, vctrs


### PR DESCRIPTION
We use Rcpp as a optional dependency, and solely for a test, hence there's no pressing need to switch out to cpp11.

This PR is purely a result of my experimentation with how good Claude Code (Sonnet 4.5) is right now with this type of task.

It performed flawlessly on a minimal prompt. I had one input in the generated plan to prevent it from trying to add later to `LinkingTo`. It then hallucinated an interface in `cpp_source()` as a solution, but corrected itself during implementation to find `[[cpp11::linking_to("later")]]`.


> Migration Summary
> 
>   Changes Made
> 
>   1. DESCRIPTION (DESCRIPTION:36-46)
>   - Replaced Rcpp with cpp11 in Suggests
>   - Kept alphabetical ordering of dependencies
>   - No changes to LinkingTo as requested
> 
>   2. inst/promise_task.cpp
>   - Changed #include <Rcpp.h> → #include <cpp11.hpp>
>   - Replaced Rcpp::Function → cpp11::function (4 occurrences)
>   - Replaced Rcpp::RObject → cpp11::sexp (2 occurrences)
>   - Replaced Rcpp::NumericVector → cpp11::writable::doubles
>   - Changed // [[Rcpp::export]] → [[cpp11::register]]
>   - Removed // [[Rcpp::depends(later)]]
>   - Added [[cpp11::linking_to("later")]] to handle later package dependency
>   - Updated inline R example to use cpp11::cpp_source()
> 
>   3. tests/testthat/test-cpp.R (test-cpp.R:3-6)
>   - Changed Rcpp::sourceCpp() → cpp11::cpp_source()